### PR TITLE
Add settings migration for 0.34.0

### DIFF
--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -5,7 +5,7 @@
  * Description:  Powering Communities with WordPress.
  * Author:       The GatherPress Community
  * Author URI:   https://gatherpress.org/
- * Version:      0.34.0-alpha.1
+ * Version:      0.34.0-alpha.2
  * Requires PHP: 7.4
  * Text Domain:  gatherpress-alpha
  * License:      GPLv2 or later (license.txt)

--- a/includes/classes/class-setup.php
+++ b/includes/classes/class-setup.php
@@ -1072,9 +1072,114 @@ class Setup {
 	 * @return void
 	 */
 	private function fix__0_34_0(): void {
+		$this->migrate_settings_to_flat();
 		$this->replace_events_list_block();
 		$this->replace_venue_block();
 		$this->replace_online_event_block();
+	}
+
+	/**
+	 * Migrates settings from nested gatherpress_* options to a single flat
+	 * gatherpress_settings option.
+	 *
+	 * Finds all gatherpress_* options that contain serialized nested arrays
+	 * (the old section/option structure) and flattens them into
+	 * gatherpress_settings. Also renames URL keys for clarity.
+	 *
+	 * @return void
+	 */
+	private function migrate_settings_to_flat(): void {
+		global $wpdb;
+
+		$new_settings = get_option( Settings::OPTION_NAME, array() );
+
+		// Key renames: old key => new key.
+		$key_renames = array(
+			'events' => 'events_url',
+			'venues' => 'venues_url',
+			'topics' => 'topics_url',
+		);
+
+		// Options to skip — these are not legacy settings options.
+		$skip_options = array(
+			Settings::OPTION_NAME,
+			'gatherpress_alpha_last_version',
+		);
+
+		// Find all gatherpress_* options.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_names = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT option_name FROM %i WHERE option_name LIKE %s',
+				$wpdb->options,
+				'gatherpress\_%'
+			)
+		);
+
+		$old_options = array();
+
+		foreach ( $option_names as $option_name ) {
+			if ( in_array( $option_name, $skip_options, true ) ) {
+				continue;
+			}
+
+			$value = get_option( $option_name );
+
+			// Only migrate options with nested array data (the old section/option structure).
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			// Check if it's a nested structure (arrays within arrays).
+			$is_nested = false;
+
+			foreach ( $value as $section_value ) {
+				if ( is_array( $section_value ) ) {
+					$is_nested = true;
+					break;
+				}
+			}
+
+			if ( ! $is_nested ) {
+				continue;
+			}
+
+			// Flatten the nested sections into the new settings.
+			foreach ( $value as $options ) {
+				if ( ! is_array( $options ) ) {
+					continue;
+				}
+
+				foreach ( $options as $key => $val ) {
+					$new_key = $key_renames[ $key ] ?? $key;
+
+					// Only migrate if not already set in the new option.
+					if ( ! isset( $new_settings[ $new_key ] ) ) {
+						$new_settings[ $new_key ] = $val;
+					}
+				}
+			}
+
+			$old_options[] = $option_name;
+		}
+
+		if ( ! empty( $old_options ) ) {
+			// Strip values that match defaults to keep the option lean.
+			$settings_instance = Settings::get_instance();
+
+			foreach ( $new_settings as $key => $value ) {
+				if ( $value === $settings_instance->get_flat_default( $key ) ) {
+					unset( $new_settings[ $key ] );
+				}
+			}
+
+			update_option( Settings::OPTION_NAME, $new_settings );
+
+			// Clean up old options.
+			foreach ( $old_options as $option_name ) {
+				delete_option( $option_name );
+			}
+		}
 	}
 
 	/**

--- a/includes/templates/settings-section.php
+++ b/includes/templates/settings-section.php
@@ -63,7 +63,16 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 		<li><?php esc_html_e( 'Replace self-closing Online Event blocks with the new inner block structure (icon and event link)', 'gatherpress-alpha' ); ?></li>
 	</ul>
 
-	<p><em><?php esc_html_e( 'This migration will automatically update all saved block content, templates, and reusable blocks in your database.', 'gatherpress-alpha' ); ?></em></p>
+	<p><strong><?php esc_html_e( 'Settings Consolidated:', 'gatherpress-alpha' ); ?></strong></p>
+	<p><?php esc_html_e( 'Plugin settings have been refactored into a single flat option for simplicity. This migration will:', 'gatherpress-alpha' ); ?></p>
+	<ul style="margin-left: 20px;">
+		<li><?php esc_html_e( 'Merge gatherpress_general and gatherpress_leadership options into gatherpress_settings', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Flatten nested section/option structure into a single key-value store', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Rename URL keys: events → events_url, venues → venues_url, topics → topics_url', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Remove old options after successful migration', 'gatherpress-alpha' ); ?></li>
+	</ul>
+
+	<p><em><?php esc_html_e( 'This migration will automatically update all saved block content, settings, templates, and reusable blocks in your database.', 'gatherpress-alpha' ); ?></em></p>
 </div>
 <p id="gatherpress-saving" class="gatherpress-saving">
 	<span class="spinner is-active"></span>


### PR DESCRIPTION
## Summary

Adds a migration for the 0.34.0 settings refactor that consolidates nested `gatherpress_*` options into a single flat `gatherpress_settings` option.

## What changed

- **`fix__0_34_0`** now calls `migrate_settings_to_flat()` before block replacements
- **`migrate_settings_to_flat()`** finds all `gatherpress_*` options with nested array data and flattens them into `gatherpress_settings`
- Applies key renames: `events` -> `events_url`, `venues` -> `venues_url`, `topics` -> `topics_url`
- Strips values that match current defaults to keep the option lean
- Deletes old options after successful migration
- Skips `gatherpress_settings` and `gatherpress_alpha_last_version` to avoid self-migration
- Updated settings-section.php template to document the settings consolidation as a 0.34.* breaking change

## Test plan

- Fresh install with existing `gatherpress_general` and `gatherpress_leadership` options -> verify they migrate into `gatherpress_settings` and old options are deleted
- Run migration via admin UI (Settings > Alpha > Apply Updates)
- Run migration via CLI: `wp gatherpress alpha fix`
- Verify settings page shows correct values after migration
- Verify migration is idempotent (running twice doesn't break anything)