### PR TITLE
Migrate venue information JSON blob into individual post meta keys

### DIFF
--- a/includes/classes/class-setup.php
+++ b/includes/classes/class-setup.php
@@ -1083,48 +1083,76 @@ class Setup {
 		$this->replace_events_list_block();
 		$this->replace_venue_block();
 		$this->replace_online_event_block();
-		$this->backfill_venue_geodata();
+		$this->migrate_venue_information_to_flat();
 	}
 
 	/**
-	 * Backfills WordPress Geodata standard meta for existing gatherpress_venue posts.
+	 * Migrates the JSON `gatherpress_venue_information` meta blob into individual
+	 * venue meta keys.
 	 *
-	 * GatherPress 0.34.0 introduced derived `geo_latitude`, `geo_longitude`, `geo_address`,
-	 * and `geo_public` post meta, written from `gatherpress_venue_information` JSON on
-	 * every subsequent save. This method pre-populates those keys for existing venues
-	 * so they don't have to be resaved manually to appear to plugins that consume the
-	 * WordPress Geodata standard (https://codex.wordpress.org/Geodata).
+	 * Pre-0.34.0 GatherPress stored the venue address, phone, website, latitude,
+	 * and longitude as a JSON-encoded string under `gatherpress_venue_information`.
 	 *
-	 * Limited to the built-in `gatherpress_venue` post type. Companion plugins that
-	 * register their own venue post types should ship their own backfill.
+	 * In 0.34.0 those become individual editor-writable meta keys
+	 * (`gatherpress_full_address`, `gatherpress_phone_number`, `gatherpress_website`,
+	 * `gatherpress_latitude`, `gatherpress_longitude`) so they can be bound to
+	 * blocks via `core/post-meta` block bindings without an intermediate JSON
+	 * parse step.
+	 *
+	 * For each venue post that still carries the JSON blob this method:
+	 * - Decodes the JSON,
+	 * - Writes any non-empty fields to the new individual meta keys
+	 *   (without overwriting values the new editor has already saved),
+	 * - Deletes the original JSON blob.
 	 *
 	 * @return void
 	 */
-	private function backfill_venue_geodata(): void {
-		if ( ! class_exists( Venue::class ) ) {
-			return;
-		}
+	private function migrate_venue_information_to_flat(): void {
+		global $wpdb;
 
-		$venue = Venue::get_instance();
+		// Map JSON keys to the new individual meta keys.
+		$field_map = array(
+			'fullAddress' => 'gatherpress_address',
+			'latitude'    => 'gatherpress_latitude',
+			'longitude'   => 'gatherpress_longitude',
+			'phoneNumber' => 'gatherpress_phone',
+			'website'     => 'gatherpress_website',
+		);
 
-		if ( ! method_exists( $venue, 'set_geodata' ) ) {
-			return;
-		}
-
-		$venue_ids = get_posts(
-			array(
-				'post_type'              => 'gatherpress_venue',
-				'post_status'            => array( 'publish', 'draft', 'pending', 'private', 'future', 'trash' ),
-				'posts_per_page'         => -1,
-				'fields'                 => 'ids',
-				'no_found_rows'          => true,
-				'update_post_term_cache' => false,
-				'update_post_meta_cache' => false,
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s",
+				'gatherpress_venue_information'
 			)
 		);
 
-		foreach ( $venue_ids as $venue_id ) {
-			$venue->set_geodata( (int) $venue_id );
+		foreach ( $rows as $row ) {
+			$post_id = (int) $row->post_id;
+			$decoded = json_decode( (string) $row->meta_value, true );
+
+			if ( is_array( $decoded ) ) {
+				foreach ( $field_map as $json_key => $meta_key ) {
+					if ( ! isset( $decoded[ $json_key ] ) ) {
+						continue;
+					}
+
+					$value = (string) $decoded[ $json_key ];
+
+					if ( '' === $value ) {
+						continue;
+					}
+
+					// Don't overwrite values the new editor has already written.
+					if ( '' !== (string) get_post_meta( $post_id, $meta_key, true ) ) {
+						continue;
+					}
+
+					update_post_meta( $post_id, $meta_key, $value );
+				}
+			}
+
+			delete_post_meta( $post_id, 'gatherpress_venue_information' );
 		}
 	}
 

--- a/includes/templates/settings-section.php
+++ b/includes/templates/settings-section.php
@@ -72,12 +72,12 @@ defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 		<li><?php esc_html_e( 'Remove old options after successful migration', 'gatherpress-alpha' ); ?></li>
 	</ul>
 
-	<p><strong><?php esc_html_e( 'Venue Geodata Backfilled:', 'gatherpress-alpha' ); ?></strong></p>
-	<p><?php esc_html_e( 'Venues now expose the WordPress Geodata standard so other plugins (like Simple Location) can read venue coordinates directly. This migration will:', 'gatherpress-alpha' ); ?></p>
+	<p><strong><?php esc_html_e( 'Venue Information Split Into Individual Meta Keys:', 'gatherpress-alpha' ); ?></strong></p>
+	<p><?php esc_html_e( 'Venue address, phone, website, and coordinates are now stored as individual post meta keys instead of a single JSON blob, so they can be bound to blocks via core/post-meta block bindings. This migration will:', 'gatherpress-alpha' ); ?></p>
 	<ul style="margin-left: 20px;">
-		<li><?php esc_html_e( 'Derive geo_latitude, geo_longitude, and geo_address from each venue\'s existing information', 'gatherpress-alpha' ); ?></li>
-		<li><?php esc_html_e( 'Set geo_public to 1 for published venues and 0 for all other statuses', 'gatherpress-alpha' ); ?></li>
-		<li><?php esc_html_e( 'Apply to the built-in gatherpress_venue post type only — custom venue post types are not touched', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Decode the gatherpress_venue_information JSON for each venue', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Write each non-empty field to its own meta key: gatherpress_address, gatherpress_latitude, gatherpress_longitude, gatherpress_phone, gatherpress_website', 'gatherpress-alpha' ); ?></li>
+		<li><?php esc_html_e( 'Remove the original JSON blob once the individual fields are written', 'gatherpress-alpha' ); ?></li>
 	</ul>
 
 	<p><em><?php esc_html_e( 'This migration will automatically update all saved block content, settings, templates, and reusable blocks in your database.', 'gatherpress-alpha' ); ?></em></p>


### PR DESCRIPTION
<!--
Please do your best to fill out this template.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code ideally includes documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds a one-shot migration that paves over the data side of GatherPress PR [#1517](https://github.com/GatherPress/gatherpress/pull/1517) — splitting the legacy `gatherpress_venue_information` JSON-blob post meta into five individual post meta keys so venue fields can be bound to blocks via `core/post-meta` block bindings without an intermediate JSON parse step.

The migration runs inside the existing `fix__0_34_0()` routine in `class-setup.php`. For every row in `wp_postmeta` whose `meta_key` is `gatherpress_venue_information`, it:

1. JSON-decodes the stored blob.
2. Maps each non-empty field from the JSON shape to its individual meta key:
   - `fullAddress` → `gatherpress_address`
   - `phoneNumber` → `gatherpress_phone`
   - `website`     → `gatherpress_website`
   - `latitude`    → `gatherpress_latitude`
   - `longitude`   → `gatherpress_longitude`
3. Writes each non-empty value via `update_post_meta()` — but **only** when the corresponding new meta key isn't already populated, so a user who has already saved a venue under the new editor doesn't have their values clobbered by older JSON data.
4. Deletes the original `gatherpress_venue_information` row once the individual fields are written.

The migration is post-type agnostic — it walks every `gatherpress_venue_information` row in `wp_postmeta` regardless of which post type carries it, so companion plugins that registered their own venue post type are migrated alongside the built-in `gatherpress_venue`.

The unreleased alpha-only `geo_latitude` / `geo_longitude` / `geo_address` / `geo_public` derived meta is intentionally **not** cleaned up here. Those rows only ever existed on alpha-track sites, the new code in core no longer reads or writes them, and they're harmless orphans — leaving them avoids extra database churn during the upgrade.

The `settings-section.php` template is updated with a new "Venue Information Split Into Individual Meta Keys" entry replacing the earlier "Venue Geodata Backfilled" copy, so users running **Apply Updates** see an accurate description of what's about to happen.

This PR ships in lockstep with [GatherPress/gatherpress#1517](https://github.com/GatherPress/gatherpress/pull/1517) and inherits the standard "Alpha owns migrations" contract that 0.34.0 has used for every other breaking change in the release (events-list block, venue/online-event block templates, settings consolidation, RSVP form-field migration, etc.). Without Alpha, sites upgrading from a pre-0.34.0 release would render blank venue blocks until the migration runs — same as every other 0.34.0 breaking change.

### How to test the Change

1. Check out this branch alongside the matching `feature/venue-information-flat-meta` branch in `gatherpress`.
2. Start from a site that already has venues stored under the old `gatherpress_venue_information` JSON blob — either a pre-0.34.0-alpha snapshot or a stable-track site upgraded to alpha.
3. Sanity-check the database state before running the migration:
   - `wp db query "SELECT post_id, meta_value FROM wp_postmeta WHERE meta_key = 'gatherpress_venue_information' LIMIT 5;"` — confirm JSON rows exist.
   - `wp db query "SELECT post_id, meta_key FROM wp_postmeta WHERE meta_key IN ('gatherpress_address','gatherpress_phone','gatherpress_website','gatherpress_latitude','gatherpress_longitude') LIMIT 5;"` — confirm the new keys aren't there yet.
4. Activate `gatherpress-alpha` on this branch and trigger the migration via either:
   - **Settings → GatherPress → Alpha**, click **Apply Updates**.
   - `wp gatherpress alpha fix` from the CLI.
5. Confirm the post-migration database state:
   - The `gatherpress_venue_information` rows are gone.
   - Each migrated venue now has individual `gatherpress_address` / `gatherpress_phone` / `gatherpress_website` / `gatherpress_latitude` / `gatherpress_longitude` meta rows populated from the original JSON.
   - Front-end venue rendering (single venue page, venue block embedded in events) still shows the same address / phone / website that was visible before.
   - Static-map images regenerate at the next venue save (cache key uses the new individual keys; existing PNGs still resolve to the same hash because the input values are identical).
6. **Idempotency / safety check.** Re-run **Apply Updates** (or `wp gatherpress alpha fix`) a second time. Migration should be a no-op — the JSON rows are already gone, and the individual keys are already populated, so the inner `if ( '' !== get_post_meta(...) )` guard short-circuits without rewriting.
7. **No-overwrite check.** Pre-populate `gatherpress_address` on a venue with a value that differs from what the JSON blob holds (simulating a user who already touched the new editor). Run the migration. Confirm the prepopulated `gatherpress_address` value is preserved and the JSON's `fullAddress` is **not** written over it. The JSON row is still deleted.
8. **Custom venue post type.** Register a third-party venue post type (`my_custom_venue`) with `gatherpress-venue-information` support, attach a venue with the legacy JSON blob, run the migration, and confirm the same five individual keys land on the custom post type — the migration is post-type agnostic by design.
9. Run the standard alpha smoke checks: `wp gatherpress alpha fix` should still complete cleanly on a multisite install with `--url=...` (the migration runs per-site via `switch_to_blog()` in `Setup::fix()`).

### Changelog Entry

> **Added.** One-shot 0.34.0 migration that splits the legacy `gatherpress_venue_information` JSON post meta into five individual meta keys (`gatherpress_address`, `gatherpress_latitude`, `gatherpress_longitude`, `gatherpress_phone`, `gatherpress_website`) so venue fields can be bound to blocks via `core/post-meta` block bindings. Runs as part of `fix__0_34_0()` via the **Apply Updates** button or `wp gatherpress alpha fix`. Existing values on the new keys are preserved — the migration never overwrites a populated key — and the legacy JSON row is deleted only after the individual keys are written.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.