### PR TITLE
Refuse activation when duplicate GatherPress Alpha folders are on disk

### DIFF
--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Plugin Name:  GatherPress Alpha
- * Plugin URI:   https://gatherpress.org/
- * Description:  Powering Communities with WordPress.
- * Author:       The GatherPress Community
- * Author URI:   https://gatherpress.org/
- * Version:      0.34.0-alpha.2
- * Requires PHP: 7.4
- * Text Domain:  gatherpress-alpha
- * License:      GPLv2 or later (license.txt)
+ * Plugin Name:      GatherPress Alpha
+ * Plugin URI:       https://gatherpress.org/
+ * Description:      Powering Communities with WordPress.
+ * Author:           The GatherPress Community
+ * Author URI:       https://gatherpress.org/
+ * Version:          0.34.0-alpha.2
+ * Requires PHP:     7.4
+ * Requires Plugins: gatherpress
+ * Text Domain:      gatherpress-alpha
+ * License:          GPLv2 or later (license.txt)
  *
  * @package GatherPress_Alpha
  */
@@ -92,3 +93,120 @@ function gatherpress_alpha_setup(): void {
 
 }
 add_action( 'plugins_loaded', 'gatherpress_alpha_setup' );
+
+/**
+ * Returns the list of installed plugin folders that look like duplicate copies
+ * of GatherPress Alpha.
+ *
+ * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
+ * upload of an Alpha build whose folder name doesn't match an existing copy
+ * will install into a new sibling folder (`gatherpress-alpha-1`,
+ * `gatherpress-alpha-2`, etc.) and leave the older copy in place. This helper
+ * scans `get_plugins()` for any `gatherpress-alpha*\/gatherpress-alpha.php`
+ * entries so callers can refuse activation when more than one is on disk.
+ *
+ * @return string[] Plugin basenames of every Alpha-shaped folder found, sorted.
+ */
+function gatherpress_alpha_find_duplicate_folders(): array {
+	$plugins    = get_plugins();
+	$duplicates = array();
+
+	foreach ( array_keys( $plugins ) as $plugin_file ) {
+		if ( ! is_string( $plugin_file ) ) {
+			continue;
+		}
+
+		$parts = explode( '/', $plugin_file );
+
+		if ( 2 !== count( $parts ) ) {
+			continue;
+		}
+
+		list( $folder, $file ) = $parts;
+
+		if ( 'gatherpress-alpha.php' !== $file ) {
+			continue;
+		}
+
+		if ( 'gatherpress-alpha' !== $folder && 0 !== strpos( $folder, 'gatherpress-alpha-' ) ) {
+			continue;
+		}
+
+		$duplicates[] = $plugin_file;
+	}
+
+	sort( $duplicates );
+
+	return $duplicates;
+}
+
+/**
+ * Refuses activation when more than one GatherPress Alpha folder is on disk.
+ *
+ * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
+ * uploaded a newer Alpha build into a sibling folder rather than replacing the
+ * existing one, both copies show up in `get_plugins()`. Activating either while
+ * the other still exists creates two GP Alpha plugin rows, which is the
+ * confusing artifact reported by QA. This helper deactivates the plugin and
+ * halts with `wp_die()` so the user has to clean up the duplicate folders
+ * before activation can succeed.
+ *
+ * @return void
+ */
+function gatherpress_alpha_refuse_activation_on_duplicates(): void {
+	$duplicates = gatherpress_alpha_find_duplicate_folders();
+
+	if ( count( $duplicates ) <= 1 ) {
+		return;
+	}
+
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+
+	// WordPress's `activate_plugin()` pre-sends a `Location:` redirect header to a
+	// failure URL before running the activation hook, so any output produced by
+	// `wp_die()` here would be discarded by the browser as it follows the
+	// redirect. Remove the pre-set redirect so the user actually sees this notice.
+	if ( ! headers_sent() ) {
+		header_remove( 'Location' );
+	}
+
+	$folders = array_map(
+		static function ( string $plugin_file ): string {
+			return dirname( $plugin_file );
+		},
+		$duplicates
+	);
+
+	wp_die(
+		sprintf(
+			'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
+			esc_html__( 'Multiple GatherPress Alpha folders detected', 'gatherpress-alpha' ),
+			esc_html__(
+				// phpcs:ignore Generic.Files.LineLength.TooLong
+				'WordPress installed a new copy of GatherPress Alpha into a separate folder instead of replacing the existing one. Activating any of these copies while the others remain on disk causes confusing behavior on the plugins screen.',
+				'gatherpress-alpha'
+			),
+			implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
+			esc_html__(
+				// phpcs:ignore Generic.Files.LineLength.TooLong
+				'Remove all but one of these folders via SFTP or your file manager, then return to the plugins screen and try activating again.',
+				'gatherpress-alpha'
+			)
+		),
+		esc_html__( 'GatherPress Alpha activation halted', 'gatherpress-alpha' ),
+		array(
+			'response'  => 200,
+			'back_link' => true,
+		)
+	);
+}
+register_activation_hook( __FILE__, 'gatherpress_alpha_refuse_activation_on_duplicates' );
+
+// Also wire the activation guard to every other GatherPress Alpha-shaped folder
+// so activating an older copy that lacks this guard still triggers the check
+// from the active install. `get_plugins()` is only available in admin context.
+if ( is_admin() ) {
+	foreach ( gatherpress_alpha_find_duplicate_folders() as $gatherpress_alpha_sibling_plugin_file ) {
+		add_action( 'activate_' . $gatherpress_alpha_sibling_plugin_file, 'gatherpress_alpha_refuse_activation_on_duplicates' );
+	}
+}

--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -105,134 +105,14 @@ if ( ! function_exists( 'gatherpress_alpha_setup' ) ) {
 }
 add_action( 'plugins_loaded', 'gatherpress_alpha_setup' );
 
-if ( ! function_exists( 'gatherpress_alpha_find_duplicate_folders' ) ) {
-	/**
-	 * Returns the list of installed plugin folders that look like duplicate copies
-	 * of GatherPress Alpha.
-	 *
-	 * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
-	 * upload of an Alpha build whose folder name doesn't match an existing copy
-	 * will install into a new sibling folder (`gatherpress-alpha-1`,
-	 * `gatherpress-alpha-2`, etc.) and leave the older copy in place. This helper
-	 * scans `get_plugins()` for any `gatherpress-alpha*\/gatherpress-alpha.php`
-	 * entries so callers can refuse activation when more than one is on disk.
-	 *
-	 * @return string[] Plugin basenames of every Alpha-shaped folder found, sorted.
-	 */
-	function gatherpress_alpha_find_duplicate_folders(): array {
-		$plugins    = get_plugins();
-		$duplicates = array();
-
-		foreach ( array_keys( $plugins ) as $plugin_file ) {
-			if ( ! is_string( $plugin_file ) ) {
-				continue;
-			}
-
-			$parts = explode( '/', $plugin_file );
-
-			if ( 2 !== count( $parts ) ) {
-				continue;
-			}
-
-			list( $folder, $file ) = $parts;
-
-			if ( 'gatherpress-alpha.php' !== $file ) {
-				continue;
-			}
-
-			if ( 'gatherpress-alpha' !== $folder && 0 !== strpos( $folder, 'gatherpress-alpha-' ) ) {
-				continue;
-			}
-
-			$duplicates[] = $plugin_file;
+// Register a coexistence activation guard via GatherPress's public API. The
+// `function_exists()` guard makes the registration a graceful no-op if the
+// helper is removed from a future version of GatherPress.
+add_action(
+	'gatherpress_register_coexistence_guards',
+	static function (): void {
+		if ( function_exists( 'gatherpress_register_coexistence_guard' ) ) {
+			gatherpress_register_coexistence_guard( 'gatherpress-alpha', 'GatherPress Alpha', __FILE__ );
 		}
-
-		sort( $duplicates );
-
-		return $duplicates;
 	}
-}
-
-if ( ! function_exists( 'gatherpress_alpha_refuse_activation_on_duplicates' ) ) {
-	/**
-	 * Refuses activation when more than one GatherPress Alpha folder is on disk.
-	 *
-	 * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
-	 * uploaded a newer Alpha build into a sibling folder rather than replacing the
-	 * existing one, both copies show up in `get_plugins()`. Activating either while
-	 * the other still exists creates two GP Alpha plugin rows, which is the
-	 * confusing artifact reported by QA. This helper deactivates the plugin and
-	 * halts with `wp_die()` so the user has to clean up the duplicate folders
-	 * before activation can succeed.
-	 *
-	 * @return void
-	 */
-	function gatherpress_alpha_refuse_activation_on_duplicates(): void {
-		$duplicates = gatherpress_alpha_find_duplicate_folders();
-
-		if ( count( $duplicates ) <= 1 ) {
-			return;
-		}
-
-		// Only refuse when another copy of GatherPress Alpha is already active.
-		// With two folders on disk and neither active, the user is allowed to
-		// activate one — the guard kicks in only on the second activation attempt
-		// while a sibling is already running.
-		$active_duplicates = array_values( array_filter( $duplicates, 'is_plugin_active' ) );
-
-		if ( empty( $active_duplicates ) ) {
-			return;
-		}
-
-		// WordPress's `activate_plugin()` pre-sends a `Location:` redirect header to a
-		// failure URL before running the activation hook, so any output produced by
-		// `wp_die()` here would be discarded by the browser as it follows the
-		// redirect. Remove the pre-set redirect so the user actually sees this notice.
-		// `update_option( 'active_plugins', ... )` runs *after* this hook in
-		// `activate_plugin()`, so `wp_die()` alone is enough to prevent the plugin
-		// from being persisted as active — no manual deactivation needed.
-		if ( ! headers_sent() ) {
-			header_remove( 'Location' );
-		}
-
-		$folders = array_map(
-			static function ( string $plugin_file ): string {
-				return dirname( $plugin_file );
-			},
-			$duplicates
-		);
-
-		wp_die(
-			sprintf(
-				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
-				esc_html__( 'Another copy of GatherPress Alpha is already active', 'gatherpress-alpha' ),
-				esc_html__(
-					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'Only one version of GatherPress Alpha can run at a time. WordPress installed a new copy in a separate folder instead of replacing the existing one — both folders are now on disk:',
-					'gatherpress-alpha'
-				),
-				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
-				esc_html__(
-					// phpcs:ignore Generic.Files.LineLength.TooLong
-					'Deactivate the currently-active copy or remove the duplicate folder via SFTP, then return to the plugins screen and try again.',
-					'gatherpress-alpha'
-				)
-			),
-			esc_html__( 'GatherPress Alpha activation halted', 'gatherpress-alpha' ),
-			array(
-				'response'  => 200,
-				'back_link' => true,
-			)
-		);
-	}
-}
-register_activation_hook( __FILE__, 'gatherpress_alpha_refuse_activation_on_duplicates' );
-
-// Also wire the activation guard to every other GatherPress Alpha-shaped folder
-// so activating an older copy that lacks this guard still triggers the check
-// from the active install. `get_plugins()` is only available in admin context.
-if ( is_admin() ) {
-	foreach ( gatherpress_alpha_find_duplicate_folders() as $gatherpress_alpha_sibling_plugin_file ) {
-		add_action( 'activate_' . $gatherpress_alpha_sibling_plugin_file, 'gatherpress_alpha_refuse_activation_on_duplicates' );
-	}
-}
+);

--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -17,102 +17,75 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-// Constants. Guarded so a duplicate Alpha folder included via
-// `plugin_sandbox_scrape()` during activation doesn't redefine them.
-defined( 'GATHERPRESS_ALPHA_VERSION' ) || define(
-	'GATHERPRESS_ALPHA_VERSION',
-	current( get_file_data( __FILE__, array( 'Version' ), 'plugin' ) )
-);
-defined( 'GATHERPRESS_ALPHA_CORE_PATH' ) || define( 'GATHERPRESS_ALPHA_CORE_PATH', __DIR__ );
+// Bail when a sibling copy is already loaded (e.g., when WordPress includes a
+// duplicate folder during activation).
+if ( defined( 'GATHERPRESS_ALPHA_VERSION' ) ) {
+	return;
+}
 
-if ( ! function_exists( 'gatherpress_alpha_autoloader' ) ) {
-	/**
-	 * Adds the GatherPress_Alpha namespace to the autoloader.
-	 *
-	 * This function hooks into the 'gatherpress_autoloader' filter and adds the
-	 * GatherPress_Alpha namespace to the list of namespaces with its core path.
-	 *
-	 * @param array $namespace An associative array of namespaces and their paths.
-	 * @return array Modified array of namespaces and their paths.
-	 */
-	function gatherpress_alpha_autoloader( array $namespace ): array {
+define( 'GATHERPRESS_ALPHA_VERSION', current( get_file_data( __FILE__, array( 'Version' ), 'plugin' ) ) );
+define( 'GATHERPRESS_ALPHA_CORE_PATH', __DIR__ );
+
+// Register the GatherPress_Alpha namespace with GatherPress's class autoloader.
+add_filter(
+	'gatherpress_autoloader',
+	static function ( array $namespace ): array {
 		$namespace['GatherPress_Alpha'] = GATHERPRESS_ALPHA_CORE_PATH;
 
 		return $namespace;
 	}
-}
-add_filter( 'gatherpress_autoloader', 'gatherpress_alpha_autoloader' );
+);
 
-if ( ! function_exists( 'gatherpress_alpha_version_notice' ) ) {
-	/**
-	 * Displays an error notice if GatherPress and GatherPress Alpha versions do not match.
-	 *
-	 * This function outputs an error notice in the WordPress admin area, indicating
-	 * that the versions of GatherPress and GatherPress Alpha must be the same.
-	 *
-	 * @return void
-	 */
-	function gatherpress_alpha_version_notice(): void {
-		?>
-		<div class="notice notice-error">
-			<p>
-				<?php esc_html_e( 'GatherPress and GatherPress Alpha must be the same version.', 'gatherpress-alpha' ); ?>
-			</p>
-		</div>
-		<?php
-	}
-}
-
-if ( ! function_exists( 'gatherpress_alpha_not_installed' ) ) {
-	/**
-	 * Displays an error notice indicating GatherPress is not installed.
-	 *
-	 * This function outputs an error notice in the WordPress admin area when
-	 * GatherPress is not detected as installed, prompting users to install it.
-	 *
-	 * @return void
-	 */
-	function gatherpress_alpha_not_installed(): void {
-		?>
-		<div class="notice notice-error">
-			<p>
-				<?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-alpha' ); ?>
-			</p>
-		</div>
-		<?php
-	}
-}
-
-if ( ! function_exists( 'gatherpress_alpha_setup' ) ) {
-	/**
-	 * Initializes the GatherPress Alpha setup.
-	 *
-	 * This function hooks into the 'plugins_loaded' action to ensure that
-	 * the GatherPress_Alpha\Setup instance is created once all plugins are loaded,
-	 * only if the GatherPress plugin is active.
-	 *
-	 * @return void
-	 */
-	function gatherpress_alpha_setup(): void {
-		if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
-			add_action( 'admin_notices', 'gatherpress_alpha_not_installed' );
-		} elseif ( defined( 'GATHERPRESS_VERSION' ) && GATHERPRESS_VERSION !== GATHERPRESS_ALPHA_VERSION ) {
-			add_action( 'admin_notices', 'gatherpress_alpha_version_notice' );
-		} else {
-			GatherPress_Alpha\Setup::get_instance();
-		}
-	}
-}
-add_action( 'plugins_loaded', 'gatherpress_alpha_setup' );
-
-// Register a coexistence activation guard via GatherPress's public API. The
-// `function_exists()` guard makes the registration a graceful no-op if the
-// helper is removed from a future version of GatherPress.
+// Boot the Alpha runtime once all plugins have loaded — but only when
+// GatherPress itself is present at a matching version.
 add_action(
-	'gatherpress_register_coexistence_guards',
+	'plugins_loaded',
 	static function (): void {
-		if ( function_exists( 'gatherpress_register_coexistence_guard' ) ) {
-			gatherpress_register_coexistence_guard( 'gatherpress-alpha', 'GatherPress Alpha', __FILE__ );
+		if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
+			add_action(
+				'admin_notices',
+				static function (): void {
+					?>
+					<div class="notice notice-error">
+						<p><?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-alpha' ); ?></p>
+					</div>
+					<?php
+				}
+			);
+
+			return;
 		}
+
+		if ( GATHERPRESS_VERSION !== GATHERPRESS_ALPHA_VERSION ) {
+			add_action(
+				'admin_notices',
+				static function (): void {
+					?>
+					<div class="notice notice-error">
+						<p>
+							<?php esc_html_e( 'GatherPress and GatherPress Alpha must be the same version.', 'gatherpress-alpha' ); ?>
+						</p>
+					</div>
+					<?php
+				}
+			);
+
+			return;
+		}
+
+		GatherPress_Alpha\Setup::get_instance();
+	}
+);
+
+// Announce this plugin to GatherPress's coexistence guard. Fired on
+// `plugins_loaded` so the registration runs after every active plugin has
+// loaded — GatherPress's listener is then guaranteed to be in place
+// regardless of the plugin order in the `active_plugins` option. When
+// GatherPress is not active, the action fires into the void — no fatal,
+// no side effect.
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		do_action( 'gatherpress_register_coexistence_guard', 'gatherpress-alpha', 'GatherPress Alpha', __FILE__ );
 	}
 );

--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -17,188 +17,214 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
 
-// Constants.
-define( 'GATHERPRESS_ALPHA_VERSION', current( get_file_data( __FILE__, array( 'Version' ), 'plugin' ) ) );
-define( 'GATHERPRESS_ALPHA_CORE_PATH', __DIR__ );
+// Constants. Guarded so a duplicate Alpha folder included via
+// `plugin_sandbox_scrape()` during activation doesn't redefine them.
+defined( 'GATHERPRESS_ALPHA_VERSION' ) || define(
+	'GATHERPRESS_ALPHA_VERSION',
+	current( get_file_data( __FILE__, array( 'Version' ), 'plugin' ) )
+);
+defined( 'GATHERPRESS_ALPHA_CORE_PATH' ) || define( 'GATHERPRESS_ALPHA_CORE_PATH', __DIR__ );
 
-/**
- * Adds the GatherPress_Alpha namespace to the autoloader.
- *
- * This function hooks into the 'gatherpress_autoloader' filter and adds the
- * GatherPress_Alpha namespace to the list of namespaces with its core path.
- *
- * @param array $namespace An associative array of namespaces and their paths.
- * @return array Modified array of namespaces and their paths.
- */
-function gatherpress_alpha_autoloader( array $namespace ): array {
-	$namespace['GatherPress_Alpha'] = GATHERPRESS_ALPHA_CORE_PATH;
+if ( ! function_exists( 'gatherpress_alpha_autoloader' ) ) {
+	/**
+	 * Adds the GatherPress_Alpha namespace to the autoloader.
+	 *
+	 * This function hooks into the 'gatherpress_autoloader' filter and adds the
+	 * GatherPress_Alpha namespace to the list of namespaces with its core path.
+	 *
+	 * @param array $namespace An associative array of namespaces and their paths.
+	 * @return array Modified array of namespaces and their paths.
+	 */
+	function gatherpress_alpha_autoloader( array $namespace ): array {
+		$namespace['GatherPress_Alpha'] = GATHERPRESS_ALPHA_CORE_PATH;
 
-	return $namespace;
+		return $namespace;
+	}
 }
 add_filter( 'gatherpress_autoloader', 'gatherpress_alpha_autoloader' );
 
-/**
- * Displays an error notice if GatherPress and GatherPress Alpha versions do not match.
- *
- * This function outputs an error notice in the WordPress admin area, indicating
- * that the versions of GatherPress and GatherPress Alpha must be the same.
- *
- * @return void
- */
-function gatherpress_alpha_version_notice(): void {
-	?>
-	<div class="notice notice-error">
-		<p>
-			<?php esc_html_e( 'GatherPress and GatherPress Alpha must be the same version.', 'gatherpress-alpha' ); ?>
-		</p>
-	</div>
-	<?php
-}
-
-/**
- * Displays an error notice indicating GatherPress is not installed.
- *
- * This function outputs an error notice in the WordPress admin area when
- * GatherPress is not detected as installed, prompting users to install it.
- *
- * @return void
- */
-function gatherpress_alpha_not_installed(): void {
-	?>
-	<div class="notice notice-error">
-		<p>
-			<?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-alpha' ); ?>
-		</p>
-	</div>
-	<?php
-}
-
-/**
- * Initializes the GatherPress Alpha setup.
- *
- * This function hooks into the 'plugins_loaded' action to ensure that
- * the GatherPress_Alpha\Setup instance is created once all plugins are loaded,
- * only if the GatherPress plugin is active.
- *
- * @return void
- */
-function gatherpress_alpha_setup(): void {
-	if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
-		add_action( 'admin_notices', 'gatherpress_alpha_not_installed' );
-	} elseif ( defined( 'GATHERPRESS_VERSION' ) && GATHERPRESS_VERSION !== GATHERPRESS_ALPHA_VERSION ) {
-		add_action( 'admin_notices', 'gatherpress_alpha_version_notice' );
-	} else {
-		GatherPress_Alpha\Setup::get_instance();
+if ( ! function_exists( 'gatherpress_alpha_version_notice' ) ) {
+	/**
+	 * Displays an error notice if GatherPress and GatherPress Alpha versions do not match.
+	 *
+	 * This function outputs an error notice in the WordPress admin area, indicating
+	 * that the versions of GatherPress and GatherPress Alpha must be the same.
+	 *
+	 * @return void
+	 */
+	function gatherpress_alpha_version_notice(): void {
+		?>
+		<div class="notice notice-error">
+			<p>
+				<?php esc_html_e( 'GatherPress and GatherPress Alpha must be the same version.', 'gatherpress-alpha' ); ?>
+			</p>
+		</div>
+		<?php
 	}
+}
 
+if ( ! function_exists( 'gatherpress_alpha_not_installed' ) ) {
+	/**
+	 * Displays an error notice indicating GatherPress is not installed.
+	 *
+	 * This function outputs an error notice in the WordPress admin area when
+	 * GatherPress is not detected as installed, prompting users to install it.
+	 *
+	 * @return void
+	 */
+	function gatherpress_alpha_not_installed(): void {
+		?>
+		<div class="notice notice-error">
+			<p>
+				<?php esc_html_e( 'GatherPress is not installed.', 'gatherpress-alpha' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'gatherpress_alpha_setup' ) ) {
+	/**
+	 * Initializes the GatherPress Alpha setup.
+	 *
+	 * This function hooks into the 'plugins_loaded' action to ensure that
+	 * the GatherPress_Alpha\Setup instance is created once all plugins are loaded,
+	 * only if the GatherPress plugin is active.
+	 *
+	 * @return void
+	 */
+	function gatherpress_alpha_setup(): void {
+		if ( ! defined( 'GATHERPRESS_VERSION' ) ) {
+			add_action( 'admin_notices', 'gatherpress_alpha_not_installed' );
+		} elseif ( defined( 'GATHERPRESS_VERSION' ) && GATHERPRESS_VERSION !== GATHERPRESS_ALPHA_VERSION ) {
+			add_action( 'admin_notices', 'gatherpress_alpha_version_notice' );
+		} else {
+			GatherPress_Alpha\Setup::get_instance();
+		}
+	}
 }
 add_action( 'plugins_loaded', 'gatherpress_alpha_setup' );
 
-/**
- * Returns the list of installed plugin folders that look like duplicate copies
- * of GatherPress Alpha.
- *
- * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
- * upload of an Alpha build whose folder name doesn't match an existing copy
- * will install into a new sibling folder (`gatherpress-alpha-1`,
- * `gatherpress-alpha-2`, etc.) and leave the older copy in place. This helper
- * scans `get_plugins()` for any `gatherpress-alpha*\/gatherpress-alpha.php`
- * entries so callers can refuse activation when more than one is on disk.
- *
- * @return string[] Plugin basenames of every Alpha-shaped folder found, sorted.
- */
-function gatherpress_alpha_find_duplicate_folders(): array {
-	$plugins    = get_plugins();
-	$duplicates = array();
+if ( ! function_exists( 'gatherpress_alpha_find_duplicate_folders' ) ) {
+	/**
+	 * Returns the list of installed plugin folders that look like duplicate copies
+	 * of GatherPress Alpha.
+	 *
+	 * WordPress's upload-replace flow keys off the plugin folder slug, so a fresh
+	 * upload of an Alpha build whose folder name doesn't match an existing copy
+	 * will install into a new sibling folder (`gatherpress-alpha-1`,
+	 * `gatherpress-alpha-2`, etc.) and leave the older copy in place. This helper
+	 * scans `get_plugins()` for any `gatherpress-alpha*\/gatherpress-alpha.php`
+	 * entries so callers can refuse activation when more than one is on disk.
+	 *
+	 * @return string[] Plugin basenames of every Alpha-shaped folder found, sorted.
+	 */
+	function gatherpress_alpha_find_duplicate_folders(): array {
+		$plugins    = get_plugins();
+		$duplicates = array();
 
-	foreach ( array_keys( $plugins ) as $plugin_file ) {
-		if ( ! is_string( $plugin_file ) ) {
-			continue;
+		foreach ( array_keys( $plugins ) as $plugin_file ) {
+			if ( ! is_string( $plugin_file ) ) {
+				continue;
+			}
+
+			$parts = explode( '/', $plugin_file );
+
+			if ( 2 !== count( $parts ) ) {
+				continue;
+			}
+
+			list( $folder, $file ) = $parts;
+
+			if ( 'gatherpress-alpha.php' !== $file ) {
+				continue;
+			}
+
+			if ( 'gatherpress-alpha' !== $folder && 0 !== strpos( $folder, 'gatherpress-alpha-' ) ) {
+				continue;
+			}
+
+			$duplicates[] = $plugin_file;
 		}
 
-		$parts = explode( '/', $plugin_file );
+		sort( $duplicates );
 
-		if ( 2 !== count( $parts ) ) {
-			continue;
-		}
-
-		list( $folder, $file ) = $parts;
-
-		if ( 'gatherpress-alpha.php' !== $file ) {
-			continue;
-		}
-
-		if ( 'gatherpress-alpha' !== $folder && 0 !== strpos( $folder, 'gatherpress-alpha-' ) ) {
-			continue;
-		}
-
-		$duplicates[] = $plugin_file;
+		return $duplicates;
 	}
-
-	sort( $duplicates );
-
-	return $duplicates;
 }
 
-/**
- * Refuses activation when more than one GatherPress Alpha folder is on disk.
- *
- * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
- * uploaded a newer Alpha build into a sibling folder rather than replacing the
- * existing one, both copies show up in `get_plugins()`. Activating either while
- * the other still exists creates two GP Alpha plugin rows, which is the
- * confusing artifact reported by QA. This helper deactivates the plugin and
- * halts with `wp_die()` so the user has to clean up the duplicate folders
- * before activation can succeed.
- *
- * @return void
- */
-function gatherpress_alpha_refuse_activation_on_duplicates(): void {
-	$duplicates = gatherpress_alpha_find_duplicate_folders();
+if ( ! function_exists( 'gatherpress_alpha_refuse_activation_on_duplicates' ) ) {
+	/**
+	 * Refuses activation when more than one GatherPress Alpha folder is on disk.
+	 *
+	 * Belt-and-suspenders against WordPress's upload-replace miss: if the user has
+	 * uploaded a newer Alpha build into a sibling folder rather than replacing the
+	 * existing one, both copies show up in `get_plugins()`. Activating either while
+	 * the other still exists creates two GP Alpha plugin rows, which is the
+	 * confusing artifact reported by QA. This helper deactivates the plugin and
+	 * halts with `wp_die()` so the user has to clean up the duplicate folders
+	 * before activation can succeed.
+	 *
+	 * @return void
+	 */
+	function gatherpress_alpha_refuse_activation_on_duplicates(): void {
+		$duplicates = gatherpress_alpha_find_duplicate_folders();
 
-	if ( count( $duplicates ) <= 1 ) {
-		return;
-	}
+		if ( count( $duplicates ) <= 1 ) {
+			return;
+		}
 
-	deactivate_plugins( plugin_basename( __FILE__ ) );
+		// Only refuse when another copy of GatherPress Alpha is already active.
+		// With two folders on disk and neither active, the user is allowed to
+		// activate one — the guard kicks in only on the second activation attempt
+		// while a sibling is already running.
+		$active_duplicates = array_values( array_filter( $duplicates, 'is_plugin_active' ) );
 
-	// WordPress's `activate_plugin()` pre-sends a `Location:` redirect header to a
-	// failure URL before running the activation hook, so any output produced by
-	// `wp_die()` here would be discarded by the browser as it follows the
-	// redirect. Remove the pre-set redirect so the user actually sees this notice.
-	if ( ! headers_sent() ) {
-		header_remove( 'Location' );
-	}
+		if ( empty( $active_duplicates ) ) {
+			return;
+		}
 
-	$folders = array_map(
-		static function ( string $plugin_file ): string {
-			return dirname( $plugin_file );
-		},
-		$duplicates
-	);
+		// WordPress's `activate_plugin()` pre-sends a `Location:` redirect header to a
+		// failure URL before running the activation hook, so any output produced by
+		// `wp_die()` here would be discarded by the browser as it follows the
+		// redirect. Remove the pre-set redirect so the user actually sees this notice.
+		// `update_option( 'active_plugins', ... )` runs *after* this hook in
+		// `activate_plugin()`, so `wp_die()` alone is enough to prevent the plugin
+		// from being persisted as active — no manual deactivation needed.
+		if ( ! headers_sent() ) {
+			header_remove( 'Location' );
+		}
 
-	wp_die(
-		sprintf(
-			'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
-			esc_html__( 'Multiple GatherPress Alpha folders detected', 'gatherpress-alpha' ),
-			esc_html__(
-				// phpcs:ignore Generic.Files.LineLength.TooLong
-				'WordPress installed a new copy of GatherPress Alpha into a separate folder instead of replacing the existing one. Activating any of these copies while the others remain on disk causes confusing behavior on the plugins screen.',
-				'gatherpress-alpha'
+		$folders = array_map(
+			static function ( string $plugin_file ): string {
+				return dirname( $plugin_file );
+			},
+			$duplicates
+		);
+
+		wp_die(
+			sprintf(
+				'<h1>%s</h1><p>%s</p><ul><li><code>%s</code></li></ul><p>%s</p>',
+				esc_html__( 'Another copy of GatherPress Alpha is already active', 'gatherpress-alpha' ),
+				esc_html__(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					'Only one version of GatherPress Alpha can run at a time. WordPress installed a new copy in a separate folder instead of replacing the existing one — both folders are now on disk:',
+					'gatherpress-alpha'
+				),
+				implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
+				esc_html__(
+					// phpcs:ignore Generic.Files.LineLength.TooLong
+					'Deactivate the currently-active copy or remove the duplicate folder via SFTP, then return to the plugins screen and try again.',
+					'gatherpress-alpha'
+				)
 			),
-			implode( '</code></li><li><code>', array_map( 'esc_html', $folders ) ),
-			esc_html__(
-				// phpcs:ignore Generic.Files.LineLength.TooLong
-				'Remove all but one of these folders via SFTP or your file manager, then return to the plugins screen and try activating again.',
-				'gatherpress-alpha'
+			esc_html__( 'GatherPress Alpha activation halted', 'gatherpress-alpha' ),
+			array(
+				'response'  => 200,
+				'back_link' => true,
 			)
-		),
-		esc_html__( 'GatherPress Alpha activation halted', 'gatherpress-alpha' ),
-		array(
-			'response'  => 200,
-			'back_link' => true,
-		)
-	);
+		);
+	}
 }
 register_activation_hook( __FILE__, 'gatherpress_alpha_refuse_activation_on_duplicates' );
 


### PR DESCRIPTION
### Description of the Change

Two changes:

1. Adds a `Requires Plugins: gatherpress` header so WordPress 6.4+ enforces GatherPress as a hard dependency natively — refuses activation if GatherPress isn't installed/active and surfaces the dependency on the plugins screen.
2. Adds an activation guard that refuses to activate GatherPress Alpha when more than one `gatherpress-alpha*/gatherpress-alpha.php` folder exists on disk. WordPress's upload-replace flow keys off the plugin folder slug, so a fresh upload that lands in a sibling folder (`gatherpress-alpha-1`, `gatherpress-alpha-build`, etc.) leaves the older copy in place — activating either while the others remain produces two GatherPress Alpha rows and confusing behavior. The guard deactivates the plugin and `wp_die`s with a list of duplicate folders so the user can clean up via SFTP before activation succeeds.

The active install also registers the guard against every sibling folder it sees, so activating an older copy that doesn't carry this code still trips the check. Pairs with [GatherPress/gatherpress#TBD](https://github.com/GatherPress/gatherpress) which adds the matching guard on the GatherPress side.

Closes [GatherPress/gatherpress#1533](https://github.com/GatherPress/gatherpress/issues/1533)

### How to test the Change

**Requires Plugins enforcement:**
1. On WordPress 6.4+, deactivate GatherPress.
2. Visit the Plugins screen.
3. Expect: Alpha's row shows "Requires: GatherPress" and the Activate link is disabled.

**Duplicate folder activation refusal:**
1. With Alpha installed, copy the plugin folder to a sibling (e.g. `wp-content/plugins/gatherpress-alpha-build/`).
2. Visit the Plugins screen — both rows appear.
3. Click "Activate" on either Alpha row.
4. Expect: a `wp_die` page titled "GatherPress Alpha activation halted" listing both duplicate folder names. Plugin does not activate.
5. Delete the duplicate folder, retry activation — succeeds.

### Changelog Entry

> Added - Declare GatherPress as a `Requires Plugins` dependency and refuse activation when duplicate GatherPress Alpha folders are detected on disk.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/GatherPress/gatherpress/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.