### PR TITLE
Adopt jetpack-changelogger + tag-driven release automation

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,33 @@
+# Files and directories excluded from the distributable plugin zip.
+
+# Dotfiles + IDE / OS junk
+.DS_Store
+.git
+.gitignore
+.gitattributes
+.nvmrc
+.vscode
+.editorconfig
+
+# CI + repo metadata (developer-facing, not shipped to users)
+.github
+
+# Build tooling
+composer.json
+composer.lock
+package.json
+package-lock.json
+node_modules
+vendor
+
+# Developer-facing markdown
+CHANGELOG.md
+CONTRIBUTING.md
+README.md
+docs
+
+# Tests / fixtures
+tests
+test
+phpunit.xml
+phpunit.xml.dist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+Fixes #
+
+## Proposed changes:
+<!--- Explain what functional changes your PR includes -->
+*
+
+### Other information:
+
+- [ ] Have you written new tests for your changes, if applicable?
+
+## Testing instructions:
+<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
+<!-- Please include detailed testing steps, explaining how to test your change. -->
+
+* Go to '..'
+*
+
+### Changelog entry
+
+<!-- You can optionally choose to enter a changelog entry by checking the box below and supplying data. -->
+<!-- It will trigger a GitHub workflow that will create and push the entry into the branch. -->
+
+<!-- Due to org permissions, the job may fail for PRs created from a fork under GitHub organizations. -->
+<!-- In this case, you can create the entry manually with `composer changelog:add` and push it into the branch. -->
+
+<!-- If no changelog entry is required for this PR, please add the "Skip Changelog" label. -->
+
+-   [ ] Automatically create a changelog entry from the details below.
+
+<details>
+
+<summary>Changelog Entry Details</summary>
+
+#### Significance
+
+<!-- Choose only one -->
+
+-   [ ] Patch
+-   [ ] Minor
+-   [ ] Major
+
+#### Type
+
+<!-- Choose only one -->
+
+-   [ ] Added - for new features
+-   [ ] Changed - for changes in existing functionality
+-   [ ] Deprecated - for soon-to-be removed features
+-   [ ] Removed - for now removed features
+-   [ ] Fixed - for any bug fixes
+-   [ ] Security - in case of vulnerabilities
+
+#### Message
+
+<!-- Add a changelog message here -->
+
+</details>

--- a/.github/changelog/release-automation-and-changelogger
+++ b/.github/changelog/release-automation-and-changelogger
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adopt the Jetpack changelogger workflow with per-PR `.github/changelog/*` entry files and a rolled-up `CHANGELOG.md`. Add tag-driven release automation that builds a versioned distro zip and attaches it to a GitHub Release (or Pre-Release for alpha/beta/rc tags). Backfills release history from 0.29.0. See `docs/release-process.md`.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  exclude:
+    labels:
+      - 'Skip Changelog'
+      - 'Release'
+    authors:
+      - dependabot[bot]
+      - github-actions[bot]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,278 @@
+name: 'Changelog entry'
+on:
+  pull_request_target:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# Least-privilege scopes for the default GITHUB_TOKEN, matching the workflow's
+# actual API calls:
+#   contents:      write — createOrUpdateFileContents commits the changelog file to the PR branch
+#   pull-requests: write — listFiles + reading PR labels/state
+#   issues:        write — createComment for the fork-PR fallback that posts the file content
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Enforces the addition of a changelog entry (a file in the .github/changelog directory) every pull request.
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check for Skip Changelog label, or if the PR is a draft'
+        id: check-skip-label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { payload : { pull_request : { number, labels, draft = false, base : { ref } } } } = context;
+
+            // Check for Skip Changelog label
+            core.debug( 'Changelog check: Check for Skip Changelog label' );
+            const skipLabel = 'Skip Changelog';
+            const prLabels = labels.map( label => label.name );
+            const hasSkipLabel = prLabels.includes( skipLabel );
+
+            if ( hasSkipLabel ) {
+              core.info( `Skipping changelog requirement for this PR (#${ number }) because of the "${ skipLabel }" label.` );
+              core.setOutput( 'skip-changelog', 'true' );
+            } else if ( draft ) {
+              core.info( `Skipping changelog requirement for this PR (#${ number }) because it is a draft.` );
+              core.setOutput( 'skip-changelog', 'true' );
+            } else if ( ref !== 'main' ) {
+              core.info( `Skipping changelog requirement for this PR (#${ number }) because it is not against the "main" branch.` );
+              core.setOutput( 'skip-changelog', 'true' );
+            } else {
+              core.info( `No "${ skipLabel }" label found for PR #${ number }. Will check for changelog file.` );
+              core.setOutput( 'skip-changelog', 'false' );
+            }
+
+      - name: 'Check for changelog file'
+        if: steps.check-skip-label.outputs.skip-changelog != 'true'
+        id: check-changelog-file
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number } } } = context;
+
+            // Check for changelog file
+            core.debug( `Changelog check: Get list of files modified in ${ owner }/${ repo } #${ number }.` );
+
+            const fileList = [];
+            for await ( const response of github.paginate.iterator( github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: +number,
+                per_page: 100,
+            } ) ) {
+                for ( const file of response.data ) {
+                    fileList.push( file.filename );
+                    if ( file.previous_filename ) {
+                        fileList.push( file.previous_filename );
+                    }
+                }
+            }
+
+            const hasChangelogFile = fileList.some( file => {
+                core.debug( `Checking file: ${ file }` );
+                if ( file.startsWith( '.github/changelog' ) ) {
+                    core.info( `Found changelog file: ${ file }` );
+                    return true;
+                }
+                return false;
+            } );
+
+            if ( hasChangelogFile ) {
+                core.info( `PR #${ number } includes a changelog file.` );
+                core.setOutput('has-changelog-file', 'true');
+            } else {
+                core.info( `PR #${ number } does not include a changelog file.` );
+                core.setOutput('has-changelog-file', 'false');
+            }
+
+      - name: 'Check for changelog information in PR body'
+        id: check-pr-body
+        if: steps.check-skip-label.outputs.skip-changelog != 'true' && steps.check-changelog-file.outputs.has-changelog-file != 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number, body } } } = context;
+
+            // Check if the PR body exists.
+            if ( ! body ) {
+              core.info( `PR #${ number } has no description.` );
+              core.setFailed( 'Your PR does not include a changelog file and has no description to extract changelog information from. Please generate a changelog entry manually by running `composer changelog:add`.' );
+              return;
+            }
+
+            // Check if the "Automatically create a changelog entry" checkbox is checked.
+            const autoCreateRegex = /-\s+\[x\]\s+Automatically\s+create\s+a\s+changelog\s+entry\s+from\s+the\s+details\s+below/i;
+            const isAutoCreateChecked = autoCreateRegex.test( body );
+
+            if (! isAutoCreateChecked ) {
+              core.info( `PR #${ number } does not have the "Automatically create a changelog entry" checkbox checked.` );
+              core.setFailed( 'Your PR does not include a changelog file, and does not have the "Automatically create a changelog entry" checkbox checked. Please check the "Automatically create a changelog entry" checkbox and fill in all required information.' );
+              return;
+            }
+
+            core.info( `PR #${ number } has the "Automatically create a changelog entry" checkbox checked. Checking for changelog details...` );
+
+            // Extract all sections.
+            const significanceSection = body.match(/#### Significance[\s\S]*?(?=####|$)/);
+            const typeSection = body.match(/#### Type[\s\S]*?(?=####|$)/);
+            const messageSection = body.match(/#### Message\s*\n+([\s\S]*?)(?=####|<\/details>|$)/);
+
+            // Bail early if any section is missing.
+            if ( ! significanceSection || ! typeSection || ! messageSection ) {
+              core.setFailed( 'Your PR is missing one or more required sections in the changelog details. Please generate a changelog entry manually by running `composer changelog:add`.' );
+              return;
+            }
+
+            // Process significance section.
+            const significanceMatches = Array.from(
+              significanceSection[0].matchAll( /-\s+\[x\]\s+(Patch|Minor|Major)/gi )
+            );
+            if ( significanceMatches.length !== 1 ) {
+              core.setFailed( 'Your PR must have exactly one significance level checked (Patch, Minor, or Major) in the changelog details.' );
+              return;
+            }
+            const significance = significanceMatches[0][1].toLowerCase();
+
+            // Process type section.
+            const typeMatches = Array.from(
+              typeSection[0].matchAll( /-\s+\[x\]\s+(Added|Changed|Deprecated|Removed|Fixed|Security)/gi )
+            );
+            if ( typeMatches.length !== 1 ) {
+              core.setFailed( 'Your PR must have exactly one type checked (Added, Changed, Deprecated, Removed, Fixed, or Security) in the changelog details.' );
+              return;
+            }
+            const type = typeMatches[0][1].toLowerCase();
+
+            // Process message section
+            let changelogMessage = '';
+            if ( messageSection ) {
+              // Get the message and trim whitespace
+              changelogMessage = messageSection[1].trim();
+
+              // If still empty after trimming, fail
+              if ( ! changelogMessage ) {
+                core.setFailed( 'Your PR has an empty changelog message. Please provide a meaningful message in the changelog details.' );
+                return;
+              }
+            }
+
+            // All information is available, output it
+            core.info( `Extracted changelog information - Significance: ${ significance }, Type: ${ type }, Message: ${ changelogMessage }` );
+            core.setOutput( 'significance', significance );
+            core.setOutput( 'type', type );
+            core.setOutput( 'message', changelogMessage );
+            core.setOutput( 'has-changelog-info', 'true' );
+
+      - name: 'Create changelog file from PR description'
+        id: create-changelog-file
+        if: steps.check-skip-label.outputs.skip-changelog != 'true' && steps.check-changelog-file.outputs.has-changelog-file != 'true' && steps.check-pr-body.outputs.has-changelog-info == 'true'
+        env:
+          PR_MESSAGE: '${{ steps.check-pr-body.outputs.message }}'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { repo: { owner, repo }, payload : { pull_request : { number, head : { ref, repo: head_repo } } } } = context;
+
+            // Get the changelog information from the previous step.
+            const significance = '${{ steps.check-pr-body.outputs.significance }}';
+            const type = '${{ steps.check-pr-body.outputs.type }}';
+
+            // Get the raw message from the previous step and process it.
+            const rawMessage = process.env.PR_MESSAGE;
+
+            // Ensure the message is not empty.
+            if ( ! rawMessage ) {
+              core.setFailed( 'Changelog message is missing or empty. Please provide a meaningful message in the PR description.' );
+              return;
+            }
+
+            // Process the message to remove HTML comments and preserve special characters.
+            let message = rawMessage
+              .replace( /<!--[\s\S]*?-->/g, '' )
+              .trim();
+
+            // Create the changelog file content.
+            const content = [
+              `Significance: ${ significance }`,
+              `Type: ${ type }`,
+              '',
+              message,
+              ''
+            ].join( '\n' );
+
+            const path = `.github/changelog/${ number }-from-description`;
+            core.info( `Creating changelog file: ${ path }` );
+
+            // Check if PR is from a fork
+            const isFromFork = head_repo.full_name !== `${owner}/${repo}`;
+
+            if ( isFromFork ) {
+              core.info( 'PR is from a fork, so we cannot create the changelog file automatically.' );
+              const commentBody = `👋 Thanks for your contribution!
+
+              I see you have provided all the required changelog information in your PR description. To complete the process, you'll need to create a changelog file in your branch.
+
+              Please create a file named \`.github/changelog/${number}-from-description\` with this content:
+
+              \`\`\`
+              ${content}
+              \`\`\`
+
+              You can do this by either:
+              1. Running \`composer changelog:add\` in your local repository, or
+              2. Creating the file manually with the content above
+
+              Once you've committed and pushed the file to your PR branch, the checks will pass automatically.`;
+
+              let hasExistingComment = false;
+              for await ( const response of github.paginate.iterator( github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: +number,
+                per_page: 100,
+              } ) ) {
+                for ( const comment of response.data ) {
+                  if ( comment.body.includes('👋 Thanks for your contribution!') ) {
+                    hasExistingComment = true;
+                    break;
+                  }
+                }
+                if ( hasExistingComment ) {
+                  core.info( 'A comment already exists, so we will not add another one.' );
+                  break;
+                }
+              }
+
+              if ( ! hasExistingComment ) {
+                core.info( 'No existing comment found, so we will add a new one.' );
+                await github.rest.issues.createComment( {
+                  owner,
+                  repo,
+                  issue_number: number,
+                  body: commentBody
+                } );
+              }
+              return;
+            }
+
+            try {
+              await github.rest.repos.createOrUpdateFileContents( {
+                owner,
+                repo,
+                path,
+                message: 'Add changelog',
+                content: Buffer.from( content ).toString( 'base64' ),
+                branch: ref
+              } );
+
+              core.info( `Successfully created changelog file: ${ path }`);
+            } catch ( error ) {
+              core.setFailed( `Failed to create changelog file: ${ error.message }` );
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,231 @@
+name: Release
+
+# Tag-driven release automation.
+#
+# Pushing a tag like `0.34.0` cuts a stable release: distro zip is built and
+# attached to a GitHub Release, the .github/changelog/* entries get rolled up
+# into CHANGELOG.md under a new version header (and auto-PR'd back to main
+# for review).
+#
+# Pushing a tag like `0.34.0-alpha.1`, `-beta.1`, or `-rc.1` cuts a pre-release:
+# the same rolled-up changelog body that would ship at stable release shows
+# up on a GitHub Pre-Release (marked NOT-latest), but the rollup is computed
+# in an ephemeral checkout — no commit, no PR, no entry files deleted.
+#
+# Unlike the main gatherpress workflow, this one does NOT deploy to
+# wordpress.org — gatherpress-alpha is a developer companion plugin
+# distributed only via GitHub releases until the 1.0.0 milestone.
+#
+# Release-manager docs: docs/release-process.md.
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions:
+  contents: read
+
+jobs:
+  # Classify the tag so downstream jobs know which path to take.
+  prepare:
+    name: Prepare release context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.context.outputs.version }}
+      is_prerelease: ${{ steps.context.outputs.is_prerelease }}
+    steps:
+      - name: Classify tag
+        id: context
+        run: |
+          version="${GITHUB_REF_NAME}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          # Pre-release suffix detection: alpha.N, beta.N, rc.N (per SemVer).
+          if [[ "${version}" =~ -(alpha|beta|rc)\. ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${version} is a pre-release."
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Tag ${version} is a stable release."
+          fi
+
+  # Always runs: aggregate `.github/changelog/*` into a new [X.Y.Z] section
+  # and capture the section text as the release body. For stable tags we
+  # additionally commit the rollup back via an auto-PR; for pre-releases the
+  # working-dir changes evaporate when the job ends, so the entry files stay
+  # intact for the eventual stable release.
+  rollup:
+    name: Roll up changelog
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_body: ${{ steps.extract.outputs.release_body }}
+    steps:
+      - name: Checkout the tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+
+      - name: Composer install
+        env:
+          COMPOSER_PROCESS_TIMEOUT: 0
+          COMPOSER_NO_INTERACTION: 1
+          COMPOSER_NO_AUDIT: 1
+        run: composer install --optimize-autoloader --prefer-dist
+
+      - name: Roll up changelog entries
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # On pre-releases this modifies the ephemeral working dir; the
+          # changes never get pushed because the commit step below is gated
+          # on the stable path.
+          vendor/bin/changelogger write \
+            --use-version="${VERSION}" \
+            --release-date="$(date +%Y-%m-%d)" \
+            --add-pr-num \
+            --deduplicate=-1 \
+            --yes
+
+      - name: Extract release body from CHANGELOG.md
+        id: extract
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+        run: |
+          # Single-pass capture between the new [X.Y.Z] header and the next
+          # ## header. Suppresses leading blanks until first non-blank, buffers
+          # trailing blanks so they never flush.
+          section="$(awk -v ver="${VERSION}" '
+            $0 ~ "^## \\[" ver "\\]" { capture = 1; next }
+            /^## \[/ && capture { exit }
+            capture {
+              if ($0 ~ /[^[:space:]]/) {
+                seen = 1
+                if (buffered) { printf "%s", buffered; buffered = "" }
+                print
+              } else if (seen) {
+                buffered = buffered $0 ORS
+              }
+            }
+          ' CHANGELOG.md)"
+
+          if [[ -z "$section" ]]; then
+            if [[ "${IS_PRERELEASE}" == "true" ]]; then
+              section="_No changelog entries queued yet for this pre-release._"
+            else
+              echo "::error::Rolled-up CHANGELOG.md does not contain a [${VERSION}] section. Did the changelogger write command succeed? .github/changelog/ may have been empty at tag time."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "release_body<<EOF_BODY"
+            echo "$section"
+            echo "EOF_BODY"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR with rolled-up changelog (stable only)
+        if: needs.prepare.outputs.is_prerelease == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          branch="release/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "${branch}"
+          git add CHANGELOG.md .github/changelog/
+          git commit -m "Roll up changelog for ${VERSION}"
+          git push origin "${branch}"
+
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "Roll up changelog for ${VERSION}" \
+            --body "Automated rollup of \`.github/changelog/*\` entries into \`CHANGELOG.md\` as part of the ${VERSION} release. Merge after confirming the rendered release body at https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION} looks right." \
+            --label "Skip Changelog"
+
+  # Build the distro zip via wp-scripts plugin-zip (already in package.json).
+  # Same artifact for both pre-release and stable paths.
+  build:
+    name: Build distro zip
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install JS deps
+        run: npm install
+
+      - name: Build distro zip
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # wp-scripts plugin-zip writes ./gatherpress-alpha.zip with a top-level
+          # gatherpress-alpha/ directory inside (set by package.json "name").
+          # Rename the outer file to `gatherpress-alpha.<version>.zip` so users
+          # downloading from the GitHub release see which build they got, while
+          # the internal layout stays exactly what WP expects.
+          npm run plugin-zip
+          mv gatherpress-alpha.zip "gatherpress-alpha.${VERSION}.zip"
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: distro-zip
+          path: gatherpress-alpha.${{ needs.prepare.outputs.version }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  # Create the GitHub Release (or Pre-Release) with the zip attached and the
+  # rolled-up changelog section as the body.
+  release:
+    name: Create GitHub release
+    needs: [prepare, build, rollup]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: distro-zip
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.version }}
+          name: ${{ needs.prepare.outputs.version }}
+          body: ${{ needs.rollup.outputs.release_body }}
+          files: gatherpress-alpha.${{ needs.prepare.outputs.version }}.zip
+          prerelease: ${{ needs.prepare.outputs.is_prerelease == 'true' }}
+          make_latest: ${{ needs.prepare.outputs.is_prerelease == 'false' && 'true' || 'false' }}
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,104 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Pending entries for the next release live as individual files under
+[`.github/changelog/`](.github/changelog/) and get rolled up into a new
+version section by `composer changelog:write` at release time.
+
+GatherPress Alpha tracks the GatherPress core plugin's version in lockstep —
+every GatherPress release has a matching GatherPress Alpha release that ships
+the migration code needed to bridge breaking changes between versions. This
+plugin is a temporary developer companion that goes away at GatherPress 1.0.0.
+
+## [0.33.3] - 2026-02-16
+
+Maintenance release tracking GatherPress 0.33.3.
+
+## [0.33.2] - 2026-02-08
+
+Maintenance release tracking GatherPress 0.33.2.
+
+## [0.33.1] - 2026-01-30
+
+Maintenance release tracking GatherPress 0.33.1.
+
+## [0.33.0] - 2026-01-10
+
+### Added
+- Migration scripts for the Add to Calendar block update shipping in GatherPress 0.33.0. [#13]
+- Anonymous and guest block migration scripts so events created against pre-0.33 RSVP blocks pick up the new V2 templates. [#15]
+- HTML class-name migration script to align legacy block markup with the new component-style class naming. [#16]
+- Plugin version-tracking system so the Alpha migration runner knows which migration steps have already been applied. [#19]
+- `uninstall.php` so removing the plugin cleans up its option storage. [#20]
+
+### Changed
+- Drop the standalone `gatherpress` option in favor of namespaced storage. [#14]
+
+## [0.32.3] - 2025-07-09
+
+Maintenance release tracking GatherPress 0.32.3.
+
+## [0.32.2] - 2025-05-01
+
+Maintenance release tracking GatherPress 0.32.2.
+
+## [0.32.1] - 2025-04-23
+
+Maintenance release tracking GatherPress 0.32.1. [#12]
+
+## [0.32.0] - 2025-04-12
+
+### Changed
+- Remove hardcoded test links from the Login and Registration URL handling; switch to dynamic resolution. [#9]
+- Add URL placeholders for login and registration so the migration script can rewrite legacy values. [#10]
+
+### Fixed
+- Version-string correction so the plugin reports the right version in its header. [#11]
+
+## [0.31.0] - 2024-10-04
+
+### Added
+- Backfill `datetime` meta on legacy events so the new datetime storage in GatherPress 0.31.0 sees the right values without manual intervention. [#7]
+
+## [0.30.0] - 2024-08-15
+
+### Changed
+- Refactor GatherPress Alpha around a `Setup` singleton and the gatherpress autoloader filter — first release of the plugin in its current shape. [#1]
+
+### Fixed
+- Guard against fatal errors when GatherPress isn't installed or its version doesn't match Alpha's. [#2]
+
+## [0.29.3] - 2024-06-27
+
+Maintenance release tracking GatherPress 0.29.3.
+
+## [0.29.2] - 2024-06-21
+
+Maintenance release tracking GatherPress 0.29.2.
+
+## [0.29.1] - 2024-06-11
+
+Maintenance release tracking GatherPress 0.29.1.
+
+## [0.29.0] - 2024-06-04
+
+First public release of the GatherPress Alpha companion plugin. Provides a small migration runner that fixes legacy data when GatherPress ships breaking changes — designed to be activated alongside core GatherPress in lockstep with matching version numbers.
+
+[0.33.3]: https://github.com/GatherPress/gatherpress-alpha/compare/0.33.2...0.33.3
+[0.33.2]: https://github.com/GatherPress/gatherpress-alpha/compare/0.33.1...0.33.2
+[0.33.1]: https://github.com/GatherPress/gatherpress-alpha/compare/0.33.0...0.33.1
+[0.33.0]: https://github.com/GatherPress/gatherpress-alpha/compare/0.32.3...0.33.0
+[0.32.3]: https://github.com/GatherPress/gatherpress-alpha/compare/0.32.2...0.32.3
+[0.32.2]: https://github.com/GatherPress/gatherpress-alpha/compare/0.32.1...0.32.2
+[0.32.1]: https://github.com/GatherPress/gatherpress-alpha/compare/0.32.0...0.32.1
+[0.32.0]: https://github.com/GatherPress/gatherpress-alpha/compare/0.31.0...0.32.0
+[0.31.0]: https://github.com/GatherPress/gatherpress-alpha/compare/0.30.0...0.31.0
+[0.30.0]: https://github.com/GatherPress/gatherpress-alpha/compare/0.29.3...0.30.0
+[0.29.3]: https://github.com/GatherPress/gatherpress-alpha/compare/0.29.2...0.29.3
+[0.29.2]: https://github.com/GatherPress/gatherpress-alpha/compare/0.29.1...0.29.2
+[0.29.1]: https://github.com/GatherPress/gatherpress-alpha/compare/0.29.0...0.29.1
+[0.29.0]: https://github.com/GatherPress/gatherpress-alpha/releases/tag/0.29.0

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+	"name": "gatherpress/gatherpress-alpha",
+	"description": "Companion plugin that ships migration scripts in lockstep with GatherPress releases.",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.4"
+	},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "6.0.15"
+	},
+	"scripts": {
+		"changelog:add": [
+			"composer install",
+			"vendor/bin/changelogger add"
+		],
+		"changelog:write": [
+			"composer install",
+			"vendor/bin/changelogger write --add-pr-num"
+		]
+	},
+	"extra": {
+		"changelogger": {
+			"changes-dir": ".github/changelog/",
+			"link-template": "https://github.com/GatherPress/gatherpress-alpha/compare/${old}...${new}"
+		}
+	},
+	"config": {
+		"platform": {
+			"php": "7.4"
+		}
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1040 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "afbb7869eeb3753effc1bac0f890ad53",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "v6.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-changelogger.git",
+                "reference": "2d70b910119decf81ba3d6aa02747fd7b46fdc3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-changelogger/zipball/2d70b910119decf81ba3d6aa02747fd7b46fdc3e",
+                "reference": "2d70b910119decf81ba3d6aa02747fd7b46fdc3e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": ">=7.2.5",
+                "symfony/console": "^5.4 || ^6.4 || ^7.1",
+                "symfony/process": "^5.4 || ^6.4 || ^7.1"
+            },
+            "require-dev": {
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "branch-alias": {
+                    "dev-trunk": "6.0.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/phpunit-select-config"
+                    ]
+                },
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelog\\": "lib",
+                    "Automattic\\Jetpack\\Changelogger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "keywords": [
+                "changelog",
+                "cli",
+                "dev",
+                "keepachangelog"
+            ],
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-changelogger/tree/v6.0.15"
+            },
+            "time": "2026-05-19T09:17:14+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T11:30:55+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T13:13:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.4.51",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f",
+                "reference": "467bfc56f18f5ef6d5ccb09324d7e988c1c0a98f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.51"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-26T15:53:37+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:11:13+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/136ca7d72f72b599f2631aca474a4f8e26719799",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-10T20:33:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.6.0"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,147 @@
+# Release Process
+
+This page is the single source of truth for cutting a release of GatherPress
+Alpha. The mechanics are automated by
+[`.github/workflows/release.yml`](../.github/workflows/release.yml); this
+doc covers what to expect, what to verify, and what to do when something
+doesn't go as planned.
+
+GatherPress Alpha ships in lockstep with GatherPress core — every GatherPress
+release has a matching Alpha release with the same version number. The Alpha
+plugin carries the migration code needed to bridge breaking changes between
+versions and goes away at GatherPress 1.0.0.
+
+## What gets automated
+
+Pushing a tag of the form `X.Y.Z` (stable) or `X.Y.Z-alpha.N` / `-beta.N` /
+`-rc.N` (pre-release) triggers `release.yml`. The workflow:
+
+| Tag pattern             | Distro zip                            | GitHub Release entry | Changelog body source                                                          |
+| ----------------------- | ------------------------------------- | -------------------- | ------------------------------------------------------------------------------ |
+| `0.34.0`                | `gatherpress-alpha.0.34.0.zip`        | Release (latest)     | Rolled-up `[0.34.0]` section, committed back to `CHANGELOG.md` via auto-PR     |
+| `0.34.0-alpha.1`        | `gatherpress-alpha.0.34.0-alpha.1.zip`| Pre-Release          | Rolled-up `[0.34.0-alpha.1]` section computed in an ephemeral checkout (no commit) |
+| `0.34.0-beta.1` / `-rc.1` | Same shape as alpha                 | Pre-Release          | Same shape as alpha                                                            |
+
+GatherPress Alpha does **not** deploy to wordpress.org. It is distributed only
+via GitHub releases. The distro zip's outer filename carries the version; the
+inner layout is always `gatherpress-alpha/...` so it installs cleanly under
+the right slug.
+
+## Pre-release flow
+
+**Use case.** You want testers running matched pre-release builds of
+GatherPress core to be able to download the corresponding Alpha build.
+
+**Cut it:**
+
+```bash
+git checkout main
+git pull origin main
+git tag 0.34.0-alpha.1
+git push origin 0.34.0-alpha.1
+```
+
+**What the workflow does:**
+
+1. Detects the tag is a pre-release (the `-alpha.` / `-beta.` / `-rc.` suffix).
+2. Builds `gatherpress-alpha.0.34.0-alpha.1.zip` via `npm run plugin-zip`.
+3. Runs `composer changelog:write --use-version=0.34.0-alpha.1 ...` in an ephemeral working copy and extracts the resulting `[0.34.0-alpha.1]` section as the release body. The changes never get committed anywhere — they evaporate when the job ends.
+4. Creates a GitHub **Pre-Release** with the zip attached and the rolled-up body. The Pre-Release is **not** marked as the latest release.
+5. **`.github/changelog/*` entries are left in place** so the eventual stable release still has them.
+
+**Verify after the workflow lands:**
+
+- [GitHub Releases page](https://github.com/GatherPress/gatherpress-alpha/releases) shows the new tag with a "Pre-release" badge.
+- The attached zip downloads as `gatherpress-alpha.X.Y.Z-alpha.N.zip` and unzips with a `gatherpress-alpha/` top-level directory.
+
+## Stable release flow
+
+**Pre-flight checklist:**
+
+- [ ] GatherPress core has the matching version queued (or just shipped).
+- [ ] `Version:` header in `gatherpress-alpha.php` matches the tag you're about to push.
+- [ ] `[Unreleased]`-equivalent entries in `.github/changelog/` read correctly (skim them).
+
+**Cut it:**
+
+```bash
+git checkout main
+git pull origin main
+git tag 0.34.0
+git push origin 0.34.0
+```
+
+**What the workflow does:**
+
+1. Detects the tag is stable (no `-alpha.` / `-beta.` / `-rc.` suffix).
+2. Runs `composer changelog:write --use-version=0.34.0 --release-date=<today> --add-pr-num --deduplicate=-1 --yes`. This:
+    - Aggregates every file in `.github/changelog/` into a new `## [0.34.0] - YYYY-MM-DD` section at the top of `CHANGELOG.md`.
+    - Appends `[#NNNN]` to each entry from the originating PR's merge commit subject.
+    - **Deletes** the entry files so the next cycle starts clean.
+3. Commits the rolled-up `CHANGELOG.md` + the deleted entry files to a new `release/0.34.0` branch and **opens an auto-PR back to `main`** for the release manager to merge after the release ships. The auto-PR carries the `Skip Changelog` label so the changelog gate doesn't block it.
+4. Builds `gatherpress-alpha.0.34.0.zip`.
+5. Extracts the newly-written `[0.34.0]` section from `CHANGELOG.md` as the release body.
+6. Creates a GitHub **Release** with the zip attached, marked as **latest**.
+
+**Verify after the workflow lands:**
+
+- [GitHub Releases page](https://github.com/GatherPress/gatherpress-alpha/releases) shows the new tag as "Latest release".
+- The release body matches the `[0.34.0]` section that just landed in `CHANGELOG.md` on the `release/0.34.0` branch.
+- The auto-PR titled "Roll up changelog for 0.34.0" is open against `main`. **Merge this once you've confirmed the release body renders correctly** — that returns the rolled-up `CHANGELOG.md` and the cleaned `.github/changelog/` to the long-lived branch.
+
+## Troubleshooting
+
+### "Rolled-up CHANGELOG.md does not contain a `[X.Y.Z]` section"
+
+The `rollup` job failed. Almost always means `.github/changelog/` was empty at
+tag time. Confirm by checking out the tag locally and looking:
+
+```bash
+git checkout 0.34.0
+ls .github/changelog/
+```
+
+If it's truly empty, the release shouldn't go out — there's nothing to ship.
+If there are entries but the rollup still failed, run the same command locally
+to reproduce.
+
+### Auto-PR for the changelog rollup didn't open
+
+Check the workflow run log. If `release/X.Y.Z` exists on `origin` with the
+rollup commit but no PR opened, open it manually:
+
+```bash
+gh pr create \
+  --base main \
+  --head release/0.34.0 \
+  --title "Roll up changelog for 0.34.0" \
+  --body "Automated rollup of .github/changelog/* entries." \
+  --label "Skip Changelog"
+```
+
+### I tagged the wrong commit
+
+Delete the tag locally and on origin, then re-tag:
+
+```bash
+git tag -d 0.34.0
+git push --delete origin 0.34.0
+# fix up main, then re-tag
+git tag 0.34.0
+git push origin 0.34.0
+```
+
+If the release workflow already ran against the bad tag, delete the GitHub
+Release entry (it'll auto-recreate on the new tag push) and close the bogus
+auto-PR.
+
+## Versioning conventions
+
+- **Stable**: `0.34.0`, `0.35.0`, `1.0.0`. Three numeric components, no suffix.
+- **Alpha**: `0.34.0-alpha.1`, `0.34.0-alpha.2`. Use for early in-cycle builds.
+- **Beta**: `0.34.0-beta.1`. Use for feature-complete in-cycle builds.
+- **Release candidate**: `0.34.0-rc.1`. Use for "we believe this is shippable."
+
+The version must always match the GatherPress core version that Alpha is
+bridging from. Alpha's coexistence guard refuses to boot if
+`GATHERPRESS_VERSION !== GATHERPRESS_ALPHA_VERSION`.


### PR DESCRIPTION
### Description of the Change

Ports the release automation and changelogger setup we landed for gatherpress core ([#1690](https://github.com/GatherPress/gatherpress/pull/1690), [#1692](https://github.com/GatherPress/gatherpress/pull/1692), [#1693](https://github.com/GatherPress/gatherpress/pull/1693), [#1694](https://github.com/GatherPress/gatherpress/pull/1694)) into gatherpress-alpha. Single PR because this repo has a much smaller history and no in-flight feature work to coordinate against.

**Mirrors the gatherpress core setup verbatim**, with three differences specific to this plugin:

1. **No wordpress.org deploy step** — gatherpress-alpha distributes only via GitHub releases (matches what the README has always said: "Visit the Releases section… find and click on `gatherpress-alpha.zip`"). The `release.yml` workflow stops after creating the GitHub Release.
2. **Base branch is `main`** instead of `develop` — the changelog enforcement workflow and the auto-PR target both point at `main`.
3. **Distro zip filename pattern** is `gatherpress-alpha.<version>.zip` (e.g., `gatherpress-alpha.0.34.0-alpha.3.zip`). Inner layout stays `gatherpress-alpha/...` so it installs cleanly under the right slug.

### What lands

**Infrastructure:**
- `composer.json` (new) — minimal bootstrap, just `automattic/jetpack-changelogger: 6.0.15` as `require-dev` with the same scripts + `extra.changelogger` config as gatherpress core.
- `composer.lock` (new) — pins Symfony 5.4 line (PHP 7.4 compatible per platform constraint).
- `.distignore` (new) — excludes `.github`, build tooling, dev docs, vendor, tests, etc. from the distro zip.
- `.github/changelog/.gitkeep` + one real entry (`release-automation-and-changelogger`) for this PR itself.
- `.github/release.yml` — auto-release-notes filter (excludes Skip Changelog / Release labels + bot authors).
- `.github/PULL_REQUEST_TEMPLATE.md` — Changelog Entry Details section with the auto-create checkbox.
- `.github/workflows/changelog.yml` — enforcement gate (Skip Changelog label, draft PRs, and non-`main` PRs are exempt).
- `.github/workflows/release.yml` — tag-driven release: classify pre-release vs stable, roll up changelog (commit-back only on stable), build versioned zip, create GitHub (Pre-)Release. No wp.org step.

**Content:**
- `CHANGELOG.md` (new) — curated Keep-a-Changelog backfill from 0.29.0 to 0.33.3. Versions with empty release bodies upstream are marked "Maintenance release tracking GatherPress X.Y.Z" since they were lockstep releases with no Alpha-specific changes.
- `docs/release-process.md` (new) — release manager doc covering both flows, troubleshooting, versioning conventions.

### How to test the Change

1. **Validate every entry parses:**
   ```bash
   composer install
   vendor/bin/changelogger validate    # exits 0 (verified locally)
   ```

2. **Dry-run the rollup:**
   ```bash
   cp CHANGELOG.md /tmp/backup
   vendor/bin/changelogger write --use-version=0.34.0-test --release-date="$(date +%Y-%m-%d)" --add-pr-num --deduplicate=-1 --yes
   awk '/^## \[0\.34\.0-test\]/,/^## \[/' CHANGELOG.md | head -20
   # Restore:
   mv /tmp/backup CHANGELOG.md
   git checkout HEAD -- .github/changelog/
   ```
   Should produce a `## [0.34.0-test]` section with the `release-automation-and-changelogger` entry rolled into it. Verified locally.

3. **Local zip build:**
   ```bash
   npm install
   npm run plugin-zip
   ls -lh gatherpress-alpha.zip
   unzip -l gatherpress-alpha.zip | head
   ```
   Should produce a ~bytes-on-disk zip with `gatherpress-alpha/` as the top-level dir inside.

4. **End-to-end** — after merge, push a throwaway pre-release tag:
   ```bash
   git checkout main && git pull origin main
   git tag 0.34.0-alpha.3 && git push origin 0.34.0-alpha.3
   ```
   Confirm: GitHub Pre-Release appears with `gatherpress-alpha.0.34.0-alpha.3.zip` attached and the `[0.34.0-alpha.3]` rolled-up body. Then delete the Pre-Release + tag.

### Note on the README

The README currently says testers should "find and click on `gatherpress-alpha.zip`" — after this PR, the asset is `gatherpress-alpha.<version>.zip`. The versioned filename is actually MORE useful here (users explicitly pick the build that matches their gatherpress core version), but the README's wording lags reality by a sentence. Worth a follow-up update; I didn't bundle it here to keep the diff focused on the automation.

### Changelog Entry

Ships its own entry under `.github/changelog/release-automation-and-changelogger`:

> Significance: minor
> Type: added
>
> Adopt the Jetpack changelogger workflow with per-PR `.github/changelog/*` entry files and a rolled-up `CHANGELOG.md`. Add tag-driven release automation that builds a versioned distro zip and attaches it to a GitHub Release (or Pre-Release for alpha/beta/rc tags). Backfills release history from 0.29.0. See `docs/release-process.md`.

### Credits

Props @mauteri

### Checklist:

- [x] I agree to follow this project's **Code of Conduct**.
- [x] I have updated the documentation accordingly (`docs/release-process.md`).
- [x] Changelog entry included.
- [x] N/A for unit tests — workflow + content only.