### PR TITLE
Backfill changelog entries for the six 0.34.0-cycle PRs that landed before the gate

### DIFF
--- a/.github/changelog/alpha-tab-multisite-network
+++ b/.github/changelog/alpha-tab-multisite-network
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only render the Alpha tab on the Network admin when WordPress is running in multisite mode. Single-site installs see it under the regular Events settings as before. [#31]

--- a/.github/changelog/cli-autoload-path-fix
+++ b/.github/changelog/cli-autoload-path-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the `Commands\\Cli` autoload path so `wp gatherpress alpha fix` and other WP-CLI commands resolve correctly. [#34]

--- a/.github/changelog/refuse-duplicate-alpha-activation
+++ b/.github/changelog/refuse-duplicate-alpha-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refuse activation when a duplicate GatherPress Alpha folder is on disk, mirroring the coexistence guard core GatherPress ships. Prevents silent class collisions when WordPress includes both copies during activation. [#33]

--- a/.github/changelog/settings-migration-0.34.0
+++ b/.github/changelog/settings-migration-0.34.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add settings migration so legacy GatherPress settings storage upgrades cleanly into the 0.34.0 flat / config-driven Settings API. [#29]

--- a/.github/changelog/venue-geodata-migration
+++ b/.github/changelog/venue-geodata-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Migrate legacy venue address data into the WordPress Geodata standard meta keys (`geo_latitude` / `geo_longitude` / `geo_address`) that core GatherPress 0.34.0 now publishes. [#30]

--- a/.github/changelog/venue-information-meta-migration
+++ b/.github/changelog/venue-information-meta-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Migrate the legacy `gatherpress_venue_information` JSON blob into the individual post-meta keys (address, phone, website, latitude, longitude, plus the structured-address fields) that GatherPress 0.34.0 expects for block bindings. [#32]


### PR DESCRIPTION
### Description of the Change

Same gap I closed for main gatherpress in [#1694](https://github.com/GatherPress/gatherpress/pull/1694), now for gatherpress-alpha. PR #35 set up the changelogger gate but the six 0.34.0-cycle PRs that landed before it (#29-#34) had no entries queued. This PR backfills them.

**The six:**

| PR | Type | Entry |
| --- | --- | --- |
| #29 | Added | Settings migration so legacy GatherPress settings storage upgrades cleanly into the 0.34.0 flat / config-driven Settings API |
| #30 | Added | Migrate legacy venue address data into the WordPress Geodata standard meta keys |
| #31 | Changed | Only render the Alpha tab on the Network admin when WordPress is running in multisite mode |
| #32 | Added | Migrate the legacy `gatherpress_venue_information` JSON blob into the individual post-meta keys for block bindings |
| #33 | Fixed | Refuse activation when a duplicate GatherPress Alpha folder is on disk |
| #34 | Fixed | Fix the `Commands\Cli` autoload path so `wp gatherpress alpha fix` and other WP-CLI commands resolve correctly |

(#28 was a version-bump PR — intentionally skipped.)

**Carries the `Skip Changelog` label** since the 6 backfilled entries ARE the changelog content for this PR; a meta-entry would be noise.

### Verified locally

Dry-run rollup with these entries plus the existing `release-automation-and-changelogger` produces a properly-categorized section:

```
## [0.34.0-test] - 2026-05-24
### Added
- Add settings migration... [#29]
- Adopt the Jetpack changelogger workflow... [#35]
- Migrate legacy venue address data... [#30]
- Migrate the legacy `gatherpress_venue_information` JSON blob... [#32]

### Changed
- Only render the Alpha tab on the Network admin when WordPress is running in multisite mode... [#31]

### Fixed
- Fix the `Commands\\Cli` autoload path... [#34]
- Refuse activation when a duplicate GatherPress Alpha folder is on disk... [#33]
```

### After merge

Re-tag `0.34.0-alpha.4` (avoiding `0.34.0-alpha.3` which we already used + deleted) to verify the Pre-Release body now contains the full 0.34.0-to-date picture instead of just one line.

### Credits

Props @mauteri

### Checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] N/A for documentation updates (the entries themselves are the docs).
- [x] N/A — `Skip Changelog` label applied.
- [x] N/A for unit tests — content-only PR.