### PR TITLE
Fix distro zip: produce a gatherpress-alpha/ wrapping directory

### DIFF
--- a/.github/changelog/fix-distro-zip-wrapping
+++ b/.github/changelog/fix-distro-zip-wrapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Distro zip now extracts as `gatherpress-alpha/` instead of `gatherpress-alpha.<version>/` so WordPress installs the plugin to the correct directory and Alpha's version-match guard against core GatherPress works as expected. wp-scripts plugin-zip was producing a flat zip without the wrapping folder; the release workflow now constructs the zip manually with the expected layout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,8 +162,16 @@ jobs:
             --body "Automated rollup of \`.github/changelog/*\` entries into \`CHANGELOG.md\` as part of the ${VERSION} release. Merge after confirming the rendered release body at https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION} looks right." \
             --label "Skip Changelog"
 
-  # Build the distro zip via wp-scripts plugin-zip (already in package.json).
-  # Same artifact for both pre-release and stable paths.
+  # Build the distro zip manually instead of relying on wp-scripts plugin-zip:
+  # wp-scripts in this repo produces a flat zip with files at root (no wrapping
+  # `gatherpress-alpha/` directory), which causes WordPress's plugin installer
+  # to fall back to the outer zip filename — meaning users end up with a
+  # `gatherpress-alpha.0.34.0/` plugin folder instead of `gatherpress-alpha/`,
+  # breaking the version-match guard against core GatherPress.
+  #
+  # Manual construction is bulletproof and matches the structure WordPress
+  # expects: outer file `gatherpress-alpha.<version>.zip`, inner wrapping
+  # directory `gatherpress-alpha/`, plugin files inside.
   build:
     name: Build distro zip
     needs: prepare
@@ -176,26 +184,42 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      - name: Install JS deps
-        run: npm install
-
       - name: Build distro zip
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          # wp-scripts plugin-zip writes ./gatherpress-alpha.zip with a top-level
-          # gatherpress-alpha/ directory inside (set by package.json "name").
-          # Rename the outer file to `gatherpress-alpha.<version>.zip` so users
-          # downloading from the GitHub release see which build they got, while
-          # the internal layout stays exactly what WP expects.
-          npm run plugin-zip
-          mv gatherpress-alpha.zip "gatherpress-alpha.${VERSION}.zip"
+          PLUGIN_SLUG="gatherpress-alpha"
+          ZIP_NAME="${PLUGIN_SLUG}.${VERSION}.zip"
+
+          # Stage just the distribution files into a single wrapper directory.
+          # Anything that's developer-facing (CI configs, lockfiles, dev docs,
+          # vendor/, etc.) is intentionally left out — see .distignore for the
+          # human-readable list that this mirrors.
+          mkdir -p "/tmp/package/${PLUGIN_SLUG}"
+          cp gatherpress-alpha.php "/tmp/package/${PLUGIN_SLUG}/"
+          cp uninstall.php "/tmp/package/${PLUGIN_SLUG}/"
+          cp -r includes "/tmp/package/${PLUGIN_SLUG}/"
+          cp -r public "/tmp/package/${PLUGIN_SLUG}/"
+
+          # Zip the wrapper directory so the archive has the expected layout:
+          # gatherpress-alpha/                   ← top-level entry inside the zip
+          # gatherpress-alpha/gatherpress-alpha.php
+          # gatherpress-alpha/includes/...
+          # gatherpress-alpha/public/...
+          # gatherpress-alpha/uninstall.php
+          cd /tmp/package
+          zip -r "${GITHUB_WORKSPACE}/${ZIP_NAME}" "${PLUGIN_SLUG}/"
+          cd "${GITHUB_WORKSPACE}"
+
+          # Sanity-check: the zip should have a wrapping directory, not files
+          # at root. Fail loudly if WordPress would mis-install this.
+          if unzip -l "${ZIP_NAME}" | awk 'NR>3 && NF==4 && $4!="" {n=split($4,a,"/"); if (a[1]!="'"${PLUGIN_SLUG}"'") exit 1}'; then
+            echo "Zip layout OK — all entries are under ${PLUGIN_SLUG}/."
+          else
+            echo "::error::Zip ${ZIP_NAME} has entries outside the ${PLUGIN_SLUG}/ wrapper. WordPress would mis-install this."
+            unzip -l "${ZIP_NAME}" | head -20
+            exit 1
+          fi
 
       - name: Upload zip artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Description of the Change

Caught during the alpha.3 release test: the distro zip extracts as `gatherpress-alpha.0.34.0-alpha.3/` instead of `gatherpress-alpha/`. Two consequences:

1. **WordPress installs the plugin to the wrong directory** (`wp-content/plugins/gatherpress-alpha.0.34.0-alpha.3/`).
2. **Alpha's coexistence guard against core GatherPress breaks** because the plugin loader looks for `gatherpress-alpha/gatherpress-alpha.php`, not the versioned path.

**Root cause.** `wp-scripts plugin-zip` in this repo produces a flat zip with files at the root of the archive (no wrapping directory). WordPress's plugin installer, when it sees files at root with no enclosing folder, falls back to the outer zip basename as the install path. So `gatherpress-alpha.0.34.0-alpha.3.zip` → `gatherpress-alpha.0.34.0-alpha.3/`.

`wp-scripts plugin-zip` in v28.x apparently doesn't wrap on this kind of repo (no build step, no `files` field doesn't fix it either — verified locally). Rather than fight wp-scripts, replace the build step with manual zip construction.

**The fix.** Build step now:

1. Stages just the distribution files into `/tmp/package/gatherpress-alpha/`:
    - `gatherpress-alpha.php`
    - `uninstall.php`
    - `includes/`
    - `public/`
2. Zips the wrapper directory: `zip -r gatherpress-alpha.<version>.zip gatherpress-alpha/`
3. Runs a sanity check that fails the job if any zip entry ends up outside the `gatherpress-alpha/` wrapper.

**Verified locally** — simulating the new steps produces a zip where every entry starts with `gatherpress-alpha/` and `unzip` correctly extracts to `gatherpress-alpha/`.

### Side observation

The previous build step also included `CHANGELOG.md`, `.distignore`, `.nvmrc`, etc. in the zip (wp-scripts plugin-zip wasn't reading `.distignore` either — at least not the way I'd assumed). The manual `cp` approach is explicit about what ships, which is simpler to reason about than relying on an external tool's interpretation of `.distignore`.

### How to test the Change

1. **Local reproduction** of the new build step:
    ```bash
    PLUGIN_SLUG="gatherpress-alpha"
    VERSION="0.34.0-alpha.4"
    mkdir -p "/tmp/package/${PLUGIN_SLUG}"
    cp gatherpress-alpha.php uninstall.php "/tmp/package/${PLUGIN_SLUG}/"
    cp -r includes public "/tmp/package/${PLUGIN_SLUG}/"
    (cd /tmp/package && zip -r "/tmp/${PLUGIN_SLUG}.${VERSION}.zip" "${PLUGIN_SLUG}/")
    unzip -l "/tmp/${PLUGIN_SLUG}.${VERSION}.zip" | awk 'NR>3 && NF==4 {n=split($4,a,"/"); print a[1]}' | sort -u
    # Should print only: gatherpress-alpha
    rm -rf /tmp/package /tmp/${PLUGIN_SLUG}.${VERSION}.zip
    ```

2. **End-to-end** after merge: re-cut a throwaway `0.34.0-alpha.4` tag, download the resulting zip from the Pre-Release entry, run `unzip -l` and confirm only `gatherpress-alpha/` is at the top level. Then delete the Pre-Release + tag.

### Changelog Entry

Ships its own entry under `.github/changelog/fix-distro-zip-wrapping`:

> Significance: patch
> Type: fixed
>
> Distro zip now extracts as `gatherpress-alpha/` instead of `gatherpress-alpha.<version>/`...

### Credits

Props @mauteri

### Checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] N/A for documentation updates (changelog entry covers it).
- [x] Changelog entry included.
- [x] N/A for unit tests — workflow + content only.