### PR TITLE
Sync version + SECURITY.md to 0.34.0-beta.1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities only for the current version:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.33.x  | :white_check_mark: |
-| < 0.33  | :x:                |
+| 0.34.x  | :white_check_mark: |
+| < 0.34  | :x:                |
 
 **We strongly recommend always using the latest stable version of GatherPress.** Security updates are only provided for the current release.
 

--- a/gatherpress-alpha.php
+++ b/gatherpress-alpha.php
@@ -5,7 +5,7 @@
  * Description:      Powering Communities with WordPress.
  * Author:           The GatherPress Community
  * Author URI:       https://gatherpress.org/
- * Version:          0.34.0-alpha.2
+ * Version:          0.34.0-beta.1
  * Requires PHP:     7.4
  * Requires Plugins: gatherpress
  * Text Domain:      gatherpress-alpha


### PR DESCRIPTION
Setup for the next prerelease (no changelog). Via the `gatherpress-develop` tooling:
- `gatherpress-alpha.php` version → `0.34.0-beta.1` (lockstep with core)
- `SECURITY.md` supported-versions table → `0.34.x` / `< 0.34`

Based on `version-0.34.0-beta.1` (clean rewritten history).