### PR TITLE
Ship SECURITY.md in the distributed plugin

### DIFF
--- a/.github/changelog/ship-security-md-in-release
+++ b/.github/changelog/ship-security-md-in-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ship `SECURITY.md` in the distributed plugin. The release workflow now copies it into the GitHub release zip, and a `package.json` `files` list adds it to the `npm run plugin-zip` output (`wp-scripts plugin-zip` ignores `.distignore`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,7 @@ jobs:
           mkdir -p "/tmp/package/${PLUGIN_SLUG}"
           cp gatherpress-alpha.php "/tmp/package/${PLUGIN_SLUG}/"
           cp uninstall.php "/tmp/package/${PLUGIN_SLUG}/"
+          cp SECURITY.md "/tmp/package/${PLUGIN_SLUG}/"
           cp -r includes "/tmp/package/${PLUGIN_SLUG}/"
           # public/ is optional: it only ever held front-end assets and may be
           # absent (e.g. after the injected fonts dir was removed). Guard the
@@ -209,6 +210,7 @@ jobs:
           # gatherpress-alpha/gatherpress-alpha.php
           # gatherpress-alpha/includes/...
           # gatherpress-alpha/public/...
+          # gatherpress-alpha/SECURITY.md
           # gatherpress-alpha/uninstall.php
           cd /tmp/package
           zip -r "${GITHUB_WORKSPACE}/${ZIP_NAME}" "${PLUGIN_SLUG}/"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,13 @@
 {
 	"name": "gatherpress-alpha",
+	"files": [
+		"gatherpress-alpha.php",
+		"uninstall.php",
+		"includes",
+		"public",
+		"CHANGELOG.md",
+		"SECURITY.md"
+	],
 	"scripts": {
 		"plugin-zip": "wp-scripts plugin-zip"
 	},


### PR DESCRIPTION
Resolves the gatherpress-alpha half of GatherPress/gatherpress#1718 (core half: GatherPress/gatherpress#1727). Tracked on the core ticket per that issue's note — no separate alpha issue.

## Problem
`SECURITY.md` shipped in neither alpha distribution path:

1. **GitHub release zip** (the only way alpha is distributed) is built manually in `release.yml` from an explicit allowlist (`gatherpress-alpha.php`, `uninstall.php`, `includes/`, `public/`) that never copied `SECURITY.md`. **This is the real gap.**
2. **`npm run plugin-zip`** — the issue assumed this honors `.distignore`, but `wp-scripts plugin-zip` ignores `.distignore` entirely and builds from a fixed allowlist (`includes/**`, `changelog.*`, `readme.*`, ...), which doesn't match `SECURITY.md`.

## Fix
- **`release.yml`**: `cp SECURITY.md` into the staged `gatherpress-alpha/` wrapper so it lands in the released zip.
- **`package.json`**: add a `files` list so `plugin-zip` switches to `npm-packlist` and includes `SECURITY.md`. The list mirrors the `release.yml` fileset (`gatherpress-alpha.php`, `uninstall.php`, `includes`, `public`, `CHANGELOG.md`) plus `SECURITY.md`. Verified with `npm-packlist` — `SECURITY.md` is now present.

Alpha distributes only via GitHub releases, so there is no wordpress.org flow to change.

## Acceptance criteria
- [x] `SECURITY.md` present in `npm run plugin-zip` artifact
- [x] `SECURITY.md` present in the gatherpress-alpha GitHub release zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)